### PR TITLE
Validate null region in WizClient

### DIFF
--- a/WizCloud.Tests/WizClientConstructorTests.cs
+++ b/WizCloud.Tests/WizClientConstructorTests.cs
@@ -1,0 +1,16 @@
+using WizCloud.Enums;
+
+namespace WizCloud.Tests {
+    [TestClass]
+    public sealed class WizClientConstructorTests {
+        [TestMethod]
+        public void Constructor_WithNullRegionString_ThrowsArgumentNullException() {
+            Assert.ThrowsException<ArgumentNullException>(() => new WizClient("token", (string?)null));
+        }
+
+        [TestMethod]
+        public void Constructor_WithNullRegionEnum_ThrowsArgumentNullException() {
+            Assert.ThrowsException<ArgumentNullException>(() => new WizClient("token", (WizRegion?)null));
+        }
+    }
+}

--- a/WizCloud.Tests/WizCloud.Tests.csproj
+++ b/WizCloud.Tests/WizCloud.Tests.csproj
@@ -23,6 +23,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\WizCloud\WizCloud.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
 

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -32,6 +32,9 @@ namespace WizCloud
             if (string.IsNullOrWhiteSpace(token))
                 throw new ArgumentException("Token cannot be null or empty", nameof(token));
 
+            if (region is null)
+                throw new ArgumentNullException(nameof(region));
+
             _apiEndpoint = $"https://api.{region}.app.wiz.io/graphql";
             _httpClient = new HttpClient();
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
@@ -44,12 +47,15 @@ namespace WizCloud
         /// <param name="token">The Wiz service account token for authentication.</param>
         /// <param name="region">The Wiz region enumeration value.</param>
         /// <exception cref="ArgumentException">Thrown when the token is null or empty.</exception>
-        public WizClient(string token, WizRegion region)
+        public WizClient(string token, WizRegion? region)
         {
             if (string.IsNullOrWhiteSpace(token))
                 throw new ArgumentException("Token cannot be null or empty", nameof(token));
 
-            var regionString = WizRegionHelper.ToApiString(region);
+            if (region is null)
+                throw new ArgumentNullException(nameof(region));
+
+            var regionString = WizRegionHelper.ToApiString(region.Value);
             _apiEndpoint = $"https://api.{regionString}.app.wiz.io/graphql";
             _httpClient = new HttpClient();
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);


### PR DESCRIPTION
## Summary
- guard against null `region` in WizClient constructors
- make region enum parameter nullable
- add tests for null region handling
- reference WizCloud project in test project

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688870b0a190832e93c4b29d32e7eaee