### PR TITLE
Fix WizUser DeletedAt timezone

### DIFF
--- a/WizCloud/Models/WizUser.cs
+++ b/WizCloud/Models/WizUser.cs
@@ -108,7 +108,7 @@ namespace WizCloud.Models
                 Name = json["name"]?.GetValue<string>() ?? string.Empty,
                 Type = json["type"]?.GetValue<string>() ?? string.Empty,
                 NativeType = json["nativeType"]?.GetValue<string>(),
-                DeletedAt = json["deletedAt"]?.GetValue<DateTime?>(),
+                DeletedAt = json["deletedAt"]?.GetValue<DateTime?>()?.ToLocalTime(),
                 
                 HasAccessToSensitiveData = json["hasAccessToSensitiveData"]?.GetValue<bool>() ?? false,
                 HasAdminPrivileges = json["hasAdminPrivileges"]?.GetValue<bool>() ?? false,


### PR DESCRIPTION
## Summary
- convert `deletedAt` field to local time when parsing WizUser
- confirm build and unit tests

## Testing
- `dotnet build WizCloud.sln --configuration Release --no-restore`
- `dotnet test WizCloud.sln --configuration Release --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_6888770a3c90832e80c17cffe3034c0d