### PR TITLE
Add client credential auth samples

### DIFF
--- a/Module/Examples/GetUsers.ps1
+++ b/Module/Examples/GetUsers.ps1
@@ -37,3 +37,6 @@ $criticalUsers | ForEach-Object {
 # Example 7: Use Verbose to display progress and ensure it completes
 $null = Get-WizUser -Verbose
 
+# Example 8: Connect using client credentials
+$null = Connect-Wiz -ClientId $env:WIZ_CLIENT_ID -ClientSecret $env:WIZ_CLIENT_SECRET -TestConnection
+

--- a/WizCloud.Examples/Program.cs
+++ b/WizCloud.Examples/Program.cs
@@ -1,94 +1,14 @@
-﻿using System;
 using System.Threading.Tasks;
-using WizCloud;
-using WizCloud.Models;
+using WizCloud.Examples.Samples;
 
 namespace WizCloud.Examples
 {
-    class Program
+    internal class Program
     {
-        static async Task Main(string[] args)
+        private static async Task Main(string[] args)
         {
-            // Get the token from environment variable or replace with your actual token
-            var token = Environment.GetEnvironmentVariable("WIZ_SERVICE_ACCOUNT_TOKEN");
-            
-            if (string.IsNullOrEmpty(token))
-            {
-                Console.WriteLine("Please set the WIZ_SERVICE_ACCOUNT_TOKEN environment variable");
-                return;
-            }
-
-            try
-            {
-                // Create a new WizClient instance
-                // Default region is "eu17", you can specify others like "us1", "us2", etc.
-                using var wizClient = new WizClient(token, "eu17");
-                
-                Console.WriteLine("Fetching Wiz users...");
-                
-                // Get all users with their properties
-                var users = await wizClient.GetUsersAsync(pageSize: 50);
-                
-                Console.WriteLine($"\nFound {users.Count} users:");
-                Console.WriteLine(new string('-', 80));
-                
-                foreach (var user in users)
-                {
-                    Console.WriteLine($"\nUser: {user.Name}");
-                    Console.WriteLine($"  ID: {user.Id}");
-                    Console.WriteLine($"  Type: {user.Type}");
-                    Console.WriteLine($"  Native Type: {user.NativeType}");
-                    Console.WriteLine($"  Deleted: {(user.DeletedAt.HasValue ? user.DeletedAt.Value.ToString() : "No")}");
-                    
-                    // Security flags
-                    Console.WriteLine($"\n  Security Properties:");
-                    Console.WriteLine($"    Has Admin Privileges: {user.HasAdminPrivileges}");
-                    Console.WriteLine($"    Has High Privileges: {user.HasHighPrivileges}");
-                    Console.WriteLine($"    Has Access to Sensitive Data: {user.HasAccessToSensitiveData}");
-                    Console.WriteLine($"    Has Sensitive Data: {user.HasSensitiveData}");
-                    
-                    // Projects
-                    if (user.Projects?.Count > 0)
-                    {
-                        Console.WriteLine($"\n  Projects ({user.Projects.Count}):");
-                        foreach (var project in user.Projects)
-                        {
-                            Console.WriteLine($"    - {project.Name} ({project.Id})");
-                        }
-                    }
-                    
-                    // Cloud Account
-                    if (user.CloudAccount != null)
-                    {
-                        Console.WriteLine($"\n  Cloud Account:");
-                        Console.WriteLine($"    Provider: {user.CloudAccount.CloudProvider}");
-                        Console.WriteLine($"    Account: {user.CloudAccount.Name}");
-                        Console.WriteLine($"    External ID: {user.CloudAccount.ExternalId}");
-                    }
-                    
-                    // Issue Analytics
-                    if (user.IssueAnalytics != null)
-                    {
-                        Console.WriteLine($"\n  Issue Analytics:");
-                        Console.WriteLine($"    Total Issues: {user.IssueAnalytics.IssueCount}");
-                        Console.WriteLine($"    Critical: {user.IssueAnalytics.CriticalSeverityCount}");
-                        Console.WriteLine($"    High: {user.IssueAnalytics.HighSeverityCount}");
-                        Console.WriteLine($"    Medium: {user.IssueAnalytics.MediumSeverityCount}");
-                        Console.WriteLine($"    Low: {user.IssueAnalytics.LowSeverityCount}");
-                        Console.WriteLine($"    Informational: {user.IssueAnalytics.InformationalSeverityCount}");
-                    }
-                    
-                    Console.WriteLine(new string('-', 80));
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Error: {ex.Message}");
-                if (ex.InnerException != null)
-                {
-                    Console.WriteLine($"Inner Exception: {ex.InnerException.Message}");
-                }
-            }
+            await TokenAuthSample.RunAsync();
+            await ClientCredentialSample.RunAsync();
         }
     }
 }

--- a/WizCloud.Examples/Samples/ClientCredentialSample.cs
+++ b/WizCloud.Examples/Samples/ClientCredentialSample.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+using WizCloud;
+using WizCloud.Authentication;
+
+namespace WizCloud.Examples.Samples
+{
+    internal static class ClientCredentialSample
+    {
+        public static async Task RunAsync()
+        {
+            var clientId = Environment.GetEnvironmentVariable("WIZ_CLIENT_ID");
+            var clientSecret = Environment.GetEnvironmentVariable("WIZ_CLIENT_SECRET");
+            if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
+            {
+                Console.WriteLine("WIZ_CLIENT_ID or WIZ_CLIENT_SECRET environment variables are not set.");
+                return;
+            }
+
+            var token = await WizAuthentication.AcquireTokenAsync(clientId, clientSecret);
+            using var client = new WizClient(token);
+            var users = await client.GetUsersAsync(pageSize: 1);
+            Console.WriteLine($"Client credentials sample retrieved {users.Count} user(s).");
+        }
+    }
+}

--- a/WizCloud.Examples/Samples/TokenAuthSample.cs
+++ b/WizCloud.Examples/Samples/TokenAuthSample.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+using WizCloud;
+
+namespace WizCloud.Examples.Samples
+{
+    internal static class TokenAuthSample
+    {
+        public static async Task RunAsync()
+        {
+            var token = Environment.GetEnvironmentVariable("WIZ_SERVICE_ACCOUNT_TOKEN");
+            if (string.IsNullOrEmpty(token))
+            {
+                Console.WriteLine("WIZ_SERVICE_ACCOUNT_TOKEN environment variable is not set.");
+                return;
+            }
+
+            using var client = new WizClient(token);
+            var users = await client.GetUsersAsync(pageSize: 1);
+            Console.WriteLine($"Token auth sample retrieved {users.Count} user(s).");
+        }
+    }
+}

--- a/WizCloud.Tests/WizAuthenticationTests.cs
+++ b/WizCloud.Tests/WizAuthenticationTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizCloud.Authentication;
+using WizCloud.Enums;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizAuthenticationTests
+{
+    [TestMethod]
+    public async Task AcquireTokenAsync_WithNullClientId_ThrowsArgumentException()
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+            await WizAuthentication.AcquireTokenAsync(null!, "secret", WizRegion.EU17));
+    }
+
+    [TestMethod]
+    public async Task AcquireTokenAsync_WithNullClientSecret_ThrowsArgumentException()
+    {
+        await Assert.ThrowsExceptionAsync<ArgumentException>(async () =>
+            await WizAuthentication.AcquireTokenAsync("id", null!, WizRegion.EU17));
+    }
+}

--- a/WizCloud/Authentication/WizAuthentication.cs
+++ b/WizCloud/Authentication/WizAuthentication.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using WizCloud.Enums;
+using WizCloud.Helpers;
+
+namespace WizCloud.Authentication
+{
+    /// <summary>
+    /// Provides methods to acquire Wiz service account tokens using client credentials.
+    /// </summary>
+    public static class WizAuthentication
+    {
+        /// <summary>
+        /// Obtains a service account token from Wiz using a client ID and client secret.
+        /// </summary>
+        /// <param name="clientId">The service account client ID.</param>
+        /// <param name="clientSecret">The service account client secret.</param>
+        /// <param name="region">The Wiz region to authenticate against. Defaults to <c>eu17</c>.</param>
+        /// <returns>The service account token.</returns>
+        public static async Task<string> AcquireTokenAsync(string clientId, string clientSecret, WizRegion region = WizRegion.EU17)
+        {
+            if (string.IsNullOrWhiteSpace(clientId))
+                throw new ArgumentException("Client ID cannot be null or empty", nameof(clientId));
+            if (string.IsNullOrWhiteSpace(clientSecret))
+                throw new ArgumentException("Client secret cannot be null or empty", nameof(clientSecret));
+
+            string regionString = WizRegionHelper.ToApiString(region);
+            string authEndpoint = $"https://auth.{regionString}.app.wiz.io/oauth/token";
+
+            using var httpClient = new HttpClient();
+            using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "client_id", clientId },
+                { "client_secret", clientSecret },
+                { "grant_type", "client_credentials" },
+                { "audience", "wiz-api" }
+            });
+
+            using var response = await httpClient.PostAsync(authEndpoint, content).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            using var document = JsonDocument.Parse(responseString);
+            if (!document.RootElement.TryGetProperty("access_token", out JsonElement tokenElement))
+                throw new InvalidOperationException("Token was not found in the authentication response.");
+
+            return tokenElement.GetString() ?? throw new InvalidOperationException("Token was null in the authentication response.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- split example code into separate sample classes
- update Program.cs to call new sample classes

## Testing
- `dotnet build WizCloud.sln --configuration Release`
- `dotnet test WizCloud.Tests/WizCloud.Tests.csproj --no-build --verbosity minimal` *(fails: Invalid TargetPath)*

------
https://chatgpt.com/codex/tasks/task_e_68887921a370832e97280a8193bb9ec0