### PR TITLE
Refactor to single namespace

### DIFF
--- a/WizCloud.Examples/Program.cs
+++ b/WizCloud.Examples/Program.cs
@@ -1,6 +1,4 @@
 using System.Threading.Tasks;
-using WizCloud.Examples.Samples;
-
 namespace WizCloud.Examples
 {
     internal class Program

--- a/WizCloud.Examples/Samples/ClientCredentialSample.cs
+++ b/WizCloud.Examples/Samples/ClientCredentialSample.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Threading.Tasks;
 using WizCloud;
-using WizCloud.Authentication;
 
-namespace WizCloud.Examples.Samples
+namespace WizCloud.Examples
 {
     internal static class ClientCredentialSample
     {

--- a/WizCloud.Examples/Samples/TokenAuthSample.cs
+++ b/WizCloud.Examples/Samples/TokenAuthSample.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading.Tasks;
 using WizCloud;
 
-namespace WizCloud.Examples.Samples
+namespace WizCloud.Examples
 {
     internal static class TokenAuthSample
     {

--- a/WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs
@@ -3,10 +3,8 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 using ISUID.PowerShell;
 using WizCloud;
-using WizCloud.Authentication;
-using WizCloud.Helpers;
 
-namespace WizCloud.PowerShell.Cmdlets
+namespace WizCloud.PowerShell
 {
     /// <summary>
     /// <para type="synopsis">Connects to Wiz.io and stores authentication for the session.</para>

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
@@ -3,9 +3,8 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 using ISUID.PowerShell;
 using WizCloud;
-using WizCloud.Models;
 
-namespace WizCloud.PowerShell.Cmdlets
+namespace WizCloud.PowerShell
 {
     /// <summary>
     /// <para type="synopsis">Gets users from Wiz.io with all their properties.</para>

--- a/WizCloud.Tests/WizAuthenticationTests.cs
+++ b/WizCloud.Tests/WizAuthenticationTests.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using WizCloud.Authentication;
-using WizCloud.Enums;
+using WizCloud;
 
 namespace WizCloud.Tests;
 

--- a/WizCloud.Tests/WizClientConstructorTests.cs
+++ b/WizCloud.Tests/WizClientConstructorTests.cs
@@ -1,4 +1,4 @@
-using WizCloud.Enums;
+using WizCloud;
 
 namespace WizCloud.Tests {
     [TestClass]

--- a/WizCloud.Tests/WizRegionHelperTests.cs
+++ b/WizCloud.Tests/WizRegionHelperTests.cs
@@ -1,6 +1,5 @@
 using System;
-using WizCloud.Enums;
-using WizCloud.Helpers;
+using WizCloud;
 
 namespace WizCloud.Tests;
 

--- a/WizCloud.Tests/WizUserTests.cs
+++ b/WizCloud.Tests/WizUserTests.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Text.Json.Nodes;
-using WizCloud.Models;
+using WizCloud;
 
 namespace WizCloud.Tests;
 

--- a/WizCloud/Authentication/WizAuthentication.cs
+++ b/WizCloud/Authentication/WizAuthentication.cs
@@ -3,10 +3,9 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
-using WizCloud.Enums;
-using WizCloud.Helpers;
 
-namespace WizCloud.Authentication
+
+namespace WizCloud
 {
     /// <summary>
     /// Provides methods to acquire Wiz service account tokens using client credentials.

--- a/WizCloud/Enums/WizCloudProvider.cs
+++ b/WizCloud/Enums/WizCloudProvider.cs
@@ -1,4 +1,4 @@
-namespace WizCloud.Enums
+namespace WizCloud
 {
     /// <summary>
     /// Represents the supported cloud providers in Wiz.

--- a/WizCloud/Enums/WizRegion.cs
+++ b/WizCloud/Enums/WizRegion.cs
@@ -1,4 +1,4 @@
-namespace WizCloud.Enums
+namespace WizCloud
 {
     /// <summary>
     /// Represents the available Wiz deployment regions.

--- a/WizCloud/Enums/WizSeverity.cs
+++ b/WizCloud/Enums/WizSeverity.cs
@@ -1,4 +1,4 @@
-namespace WizCloud.Enums
+namespace WizCloud
 {
     /// <summary>
     /// Represents the severity levels for issues in Wiz.

--- a/WizCloud/Enums/WizUserType.cs
+++ b/WizCloud/Enums/WizUserType.cs
@@ -1,4 +1,4 @@
-namespace WizCloud.Enums
+namespace WizCloud
 {
     /// <summary>
     /// Represents the different types of users and identities in Wiz.

--- a/WizCloud/Helpers/WizRegionHelper.cs
+++ b/WizCloud/Helpers/WizRegionHelper.cs
@@ -1,7 +1,7 @@
 using System;
-using WizCloud.Enums;
 
-namespace WizCloud.Helpers
+
+namespace WizCloud
 {
     /// <summary>
     /// Provides helper methods for working with Wiz regions.

--- a/WizCloud/Models/WizCategory.cs
+++ b/WizCloud/Models/WizCategory.cs
@@ -1,4 +1,4 @@
-namespace WizCloud.Models
+namespace WizCloud
 {
     /// <summary>
     /// Represents a technology category in Wiz.

--- a/WizCloud/Models/WizCloudAccount.cs
+++ b/WizCloud/Models/WizCloudAccount.cs
@@ -1,4 +1,4 @@
-namespace WizCloud.Models
+namespace WizCloud
 {
     /// <summary>
     /// Represents a cloud account in Wiz.

--- a/WizCloud/Models/WizIssueAnalytics.cs
+++ b/WizCloud/Models/WizIssueAnalytics.cs
@@ -1,4 +1,4 @@
-namespace WizCloud.Models
+namespace WizCloud
 {
     /// <summary>
     /// Represents analytics data for security issues associated with a user or resource.

--- a/WizCloud/Models/WizProject.cs
+++ b/WizCloud/Models/WizProject.cs
@@ -1,4 +1,4 @@
-namespace WizCloud.Models
+namespace WizCloud
 {
     /// <summary>
     /// Represents a project in Wiz.

--- a/WizCloud/Models/WizTechnology.cs
+++ b/WizCloud/Models/WizTechnology.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-namespace WizCloud.Models
+namespace WizCloud
 {
     /// <summary>
     /// Represents technology information associated with a user or resource in Wiz.

--- a/WizCloud/Models/WizUser.cs
+++ b/WizCloud/Models/WizUser.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json.Nodes;
 
-namespace WizCloud.Models
+namespace WizCloud
 {
     /// <summary>
     /// Represents a user or identity principal in Wiz.

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -6,9 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using WizCloud.Models;
-using WizCloud.Enums;
-using WizCloud.Helpers;
+
 
 namespace WizCloud
 {


### PR DESCRIPTION
## Summary
- flatten namespaces so all library code sits under `WizCloud`
- collapse example and PowerShell namespaces
- update tests accordingly

## Testing
- `dotnet build WizCloud.sln -c Release`
- `dotnet test WizCloud.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68888107bb14832ea8e8a115fd5c3191