### PR TITLE
Fix nullability warning in WizClient tests

### DIFF
--- a/WizCloud.Tests/WizClientConstructorTests.cs
+++ b/WizCloud.Tests/WizClientConstructorTests.cs
@@ -5,7 +5,7 @@ namespace WizCloud.Tests;
 public sealed class WizClientConstructorTests {
     [TestMethod]
     public void Constructor_WithNullRegionString_ThrowsArgumentNullException() {
-        Assert.ThrowsException<ArgumentNullException>(() => new WizClient("token", (string?)null));
+        Assert.ThrowsException<ArgumentNullException>(() => new WizClient("token", (string)null!));
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- suppress nullability warning in `WizClientConstructorTests`

## Testing
- `dotnet build WizCloud.sln`
- `dotnet test WizCloud.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_688892d6659c832eaf92eda65f130206