### PR TITLE
Add WizProject retrieval API

### DIFF
--- a/WizCloud.Examples/Samples/ClientCredentialSample.cs
+++ b/WizCloud.Examples/Samples/ClientCredentialSample.cs
@@ -19,5 +19,11 @@ internal static class ClientCredentialSample {
         if (users.Count > 0) {
             Console.WriteLine($"First user type: {users[0].Type}");
         }
+
+        var projects = await client.GetProjectsAsync(pageSize: 1);
+        Console.WriteLine($"Client credentials sample retrieved {projects.Count} project(s).");
+        if (projects.Count > 0) {
+            Console.WriteLine($"First project slug: {projects[0].Slug}");
+        }
     }
 }

--- a/WizCloud.Examples/Samples/TokenAuthSample.cs
+++ b/WizCloud.Examples/Samples/TokenAuthSample.cs
@@ -17,5 +17,11 @@ internal static class TokenAuthSample {
         if (users.Count > 0) {
             Console.WriteLine($"First user type: {users[0].Type}");
         }
+
+        var projects = await client.GetProjectsAsync(pageSize: 1);
+        Console.WriteLine($"Token auth sample retrieved {projects.Count} project(s).");
+        if (projects.Count > 0) {
+            Console.WriteLine($"First project slug: {projects[0].Slug}");
+        }
     }
 }

--- a/WizCloud.Tests/GetProjectsAsyncTests.cs
+++ b/WizCloud.Tests/GetProjectsAsyncTests.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetProjectsAsyncTests {
+    [TestMethod]
+    public void MethodExistsWithCorrectReturnType() {
+        var method = typeof(WizClient).GetMethod("GetProjectsAsync");
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(Task<List<WizProject>>), method!.ReturnType);
+    }
+}


### PR DESCRIPTION
## Summary
- add `GetProjectsAsync` to WizClient for retrieving projects
- test presence of new API
- demonstrate retrieving projects in sample apps

## Testing
- `dotnet build WizCloud.sln -c Release`
- `dotnet test WizCloud.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6888a262d958832eb80a0dc4e5b782d7