### PR TITLE
Add region parameter validation

### DIFF
--- a/WizCloud.Tests/WizClientConstructorTests.cs
+++ b/WizCloud.Tests/WizClientConstructorTests.cs
@@ -13,6 +13,14 @@ public sealed class WizClientConstructorTests {
         Assert.ThrowsException<ArgumentNullException>(() => new WizClient("token", (WizRegion?)null));
     }
 
+    [DataTestMethod]
+    [DataRow("")]
+    [DataRow(" ")]
+    [DataRow("   ")]
+    public void Constructor_WithEmptyOrWhitespaceRegionString_ThrowsArgumentException(string region) {
+        Assert.ThrowsException<ArgumentException>(() => new WizClient("token", region));
+    }
+
     [TestMethod]
     public void HttpClient_IsSharedAcrossInstances() {
         using var first = new WizClient("token");

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -39,6 +39,9 @@ public class WizClient : IDisposable {
         if (region is null)
             throw new ArgumentNullException(nameof(region));
 
+        if (string.IsNullOrWhiteSpace(region))
+            throw new ArgumentException("Region cannot be empty or whitespace", nameof(region));
+
         _token = token;
         _apiEndpoint = $"https://api.{region}.app.wiz.io/graphql";
     }


### PR DESCRIPTION
## Summary
- validate region string in `WizClient` constructor
- test empty and whitespace region scenarios

## Testing
- `dotnet build WizCloud.sln -c Debug`
- `dotnet test WizCloud.Tests/WizCloud.Tests.csproj --logger "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_6888f893e2d0832e9f8c66a546335906