### PR TITLE
Fix ConfigureAwait for HttpClient

### DIFF
--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -242,10 +242,10 @@ public class WizClient : IDisposable {
                 "application/json"
             );
 
-            using (var response = await _httpClient.SendAsync(request)) {
+            using (var response = await _httpClient.SendAsync(request).ConfigureAwait(false)) {
                 response.EnsureSuccessStatusCode();
 
-                var content = await response.Content.ReadAsStringAsync();
+                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 var jsonResponse = JsonNode.Parse(content);
 
                 if (jsonResponse == null)


### PR DESCRIPTION
## Summary
- use `ConfigureAwait(false)` on remaining HttpClient calls
- verify compilation and unit tests

## Testing
- `dotnet test -c Debug`
- `dotnet build WizCloud/WizCloud.csproj -f net472`


------
https://chatgpt.com/codex/tasks/task_e_6888f897d2b0832e825fb546ce3f222c