### PR TITLE
Add safety checks when reading WizUser JSON

### DIFF
--- a/WizCloud.Tests/WizUserTests.cs
+++ b/WizCloud.Tests/WizUserTests.cs
@@ -110,4 +110,28 @@ public sealed class WizUserTests {
         Assert.AreEqual(4, user.IssueAnalytics!.HighSeverityCount);
         Assert.AreEqual(0, user.IssueAnalytics!.CriticalSeverityCount);
     }
+
+    [TestMethod]
+    public void FromJson_IncompleteJson_DoesNotThrow() {
+        string jsonString = """
+        {
+          "id": "2",
+          "name": "Jane",
+          "graphEntity": "invalid",
+          "projects": ["bad"],
+          "technology": 5,
+          "issueAnalytics": true
+        }
+        """;
+
+        JsonNode json = JsonNode.Parse(jsonString)!;
+
+        WizUser user = WizUser.FromJson(json);
+
+        Assert.AreEqual("2", user.Id);
+        Assert.AreEqual("Jane", user.Name);
+        Assert.AreEqual(0, user.Projects.Count);
+        Assert.IsNull(user.Technology);
+        Assert.IsNull(user.IssueAnalytics);
+    }
 }

--- a/WizCloud/Models/WizUser.cs
+++ b/WizCloud/Models/WizUser.cs
@@ -116,36 +116,36 @@ public class WizUser {
         };
 
         // Parse graph entity
-        var graphEntity = json["graphEntity"];
+        var graphEntity = json["graphEntity"] as JsonObject;
         if (graphEntity != null) {
             user.GraphEntityId = graphEntity["id"]?.GetValue<string>();
             user.GraphEntityType = graphEntity["type"]?.GetValue<string>();
 
-            var properties = graphEntity["properties"];
-            if (properties != null && properties is JsonObject propsObj) {
-                foreach (var prop in propsObj) {
+            var properties = graphEntity["properties"] as JsonObject;
+            if (properties != null) {
+                foreach (var prop in properties) {
                     user.GraphEntityProperties[prop.Key] = prop.Value?.ToString();
                 }
             }
         }
 
         // Parse projects
-        var projects = json["projects"];
-        if (projects != null && projects is JsonArray projectsArray) {
-            foreach (var project in projectsArray) {
-                if (project != null) {
+        var projects = json["projects"] as JsonArray;
+        if (projects != null) {
+            foreach (var project in projects) {
+                if (project is JsonObject projObj) {
                     user.Projects.Add(new WizProject {
-                        Id = project["id"]?.GetValue<string>() ?? string.Empty,
-                        Name = project["name"]?.GetValue<string>() ?? string.Empty,
-                        Slug = project["slug"]?.GetValue<string>() ?? string.Empty,
-                        IsFolder = project["isFolder"]?.GetValue<bool>() ?? false
+                        Id = projObj["id"]?.GetValue<string>() ?? string.Empty,
+                        Name = projObj["name"]?.GetValue<string>() ?? string.Empty,
+                        Slug = projObj["slug"]?.GetValue<string>() ?? string.Empty,
+                        IsFolder = projObj["isFolder"]?.GetValue<bool>() ?? false
                     });
                 }
             }
         }
 
         // Parse technology
-        var tech = json["technology"];
+        var tech = json["technology"] as JsonObject;
         if (tech != null) {
             user.Technology = new WizTechnology {
                 Id = tech["id"]?.GetValue<string>() ?? string.Empty,
@@ -155,13 +155,13 @@ public class WizUser {
                 Categories = new List<WizCategory>()
             };
 
-            var categories = tech["categories"];
-            if (categories != null && categories is JsonArray categoriesArray) {
-                foreach (var cat in categoriesArray) {
-                    if (cat != null) {
+            var categories = tech["categories"] as JsonArray;
+            if (categories != null) {
+                foreach (var cat in categories) {
+                    if (cat is JsonObject catObj) {
                         user.Technology.Categories.Add(new WizCategory {
-                            Id = cat["id"]?.GetValue<string>() ?? string.Empty,
-                            Name = cat["name"]?.GetValue<string>() ?? string.Empty
+                            Id = catObj["id"]?.GetValue<string>() ?? string.Empty,
+                            Name = catObj["name"]?.GetValue<string>() ?? string.Empty
                         });
                     }
                 }
@@ -180,7 +180,7 @@ public class WizUser {
         }
 
         // Parse issue analytics
-        var issueAnalytics = json["issueAnalytics"];
+        var issueAnalytics = json["issueAnalytics"] as JsonObject;
         if (issueAnalytics != null) {
             user.IssueAnalytics = new WizIssueAnalytics {
                 IssueCount = issueAnalytics["issueCount"]?.GetValue<int>() ?? 0,


### PR DESCRIPTION
## Summary
- ensure nested data is cast to `JsonObject`/`JsonArray` before use in `WizUser`
- add unit test confirming partial JSON does not throw

## Testing
- `dotnet build WizCloud.sln -c Release`
- `dotnet test WizCloud.sln -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6888f8acc574832e914d4acf00f32b5f