### PR TITLE
Add GraphQL query constants

### DIFF
--- a/WizCloud.Examples/Program.cs
+++ b/WizCloud.Examples/Program.cs
@@ -7,5 +7,6 @@ internal class Program {
         await MultiClientSample.RunAsync();
         await StreamingSample.RunAsync();
         await ErrorHandlingSample.RunAsync();
+        await GraphQlQueriesSample.RunAsync();
     }
 }

--- a/WizCloud.Examples/Samples/GraphQlQueriesSample.cs
+++ b/WizCloud.Examples/Samples/GraphQlQueriesSample.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+
+namespace WizCloud.Examples;
+internal static class GraphQlQueriesSample {
+    public static Task RunAsync() {
+        Console.WriteLine($"Users query length: {GraphQlQueries.UsersQuery.Length}");
+        Console.WriteLine($"Projects query length: {GraphQlQueries.ProjectsQuery.Length}");
+        return Task.CompletedTask;
+    }
+}

--- a/WizCloud.Tests/GraphQlQueriesTests.cs
+++ b/WizCloud.Tests/GraphQlQueriesTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GraphQlQueriesTests {
+    [TestMethod]
+    public void UsersQuery_ConstantExists() {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Static;
+        var field = typeof(GraphQlQueries).GetField("UsersQuery", flags);
+        Assert.IsNotNull(field);
+        Assert.AreEqual(typeof(string), field!.FieldType);
+    }
+
+    [TestMethod]
+    public void ProjectsQuery_ConstantExists() {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Static;
+        var field = typeof(GraphQlQueries).GetField("ProjectsQuery", flags);
+        Assert.IsNotNull(field);
+        Assert.AreEqual(typeof(string), field!.FieldType);
+    }
+}

--- a/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
+++ b/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
@@ -1,0 +1,17 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizClientGraphQlQueriesTests {
+    [TestMethod]
+    public void WizClient_UsesGraphQlQueryConstants() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
+        var source = File.ReadAllText(filePath);
+        StringAssert.Contains(source, "GraphQlQueries.UsersQuery");
+        StringAssert.Contains(source, "GraphQlQueries.ProjectsQuery");
+    }
+}

--- a/WizCloud/GraphQlQueries.cs
+++ b/WizCloud/GraphQlQueries.cs
@@ -1,0 +1,37 @@
+namespace WizCloud;
+/// <summary>
+/// Provides GraphQL queries used by <see cref="WizClient"/>.
+/// </summary>
+public static class GraphQlQueries {
+    /// <summary>
+    /// Query for retrieving cloud identity principals.
+    /// </summary>
+    public const string UsersQuery = @"query CloudIdentityPrincipals($first: Int, $after: String, $filterBy: CloudResourceV2Filters) {
+            cloudResourcesV2(first: $first, after: $after, filterBy: $filterBy) {
+                pageInfo { hasNextPage endCursor }
+                nodes { ...PrincipalDetails }
+            }
+        }
+        fragment PrincipalDetails on CloudResourceV2 {
+            id name type nativeType deletedAt
+            graphEntity { id type properties }
+            hasAccessToSensitiveData hasAdminPrivileges hasHighPrivileges hasSensitiveData
+            projects { id name slug isFolder }
+            technology { id icon name categories { id name } description }
+            cloudAccount { id name cloudProvider externalId }
+            issueAnalytics {
+                issueCount informationalSeverityCount lowSeverityCount
+                mediumSeverityCount highSeverityCount criticalSeverityCount
+            }
+        }";
+
+    /// <summary>
+    /// Query for retrieving projects.
+    /// </summary>
+    public const string ProjectsQuery = @"query Projects($first: Int, $after: String) {
+            projects(first: $first, after: $after) {
+                pageInfo { hasNextPage endCursor }
+                nodes { id name slug isFolder }
+            }
+        }";
+}

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -113,24 +113,7 @@ public class WizClient : IDisposable {
     /// <param name="after">The cursor for pagination, if retrieving subsequent pages.</param>
     /// <returns>A tuple containing the users, whether there's a next page, and the cursor for the next page.</returns>
     private async Task<(List<WizUser> Users, bool HasNextPage, string? EndCursor)> GetUsersPageAsync(int first, string? after = null) {
-        var query = @"query CloudIdentityPrincipals($first: Int, $after: String, $filterBy: CloudResourceV2Filters) { 
-            cloudResourcesV2(first: $first, after: $after, filterBy: $filterBy) { 
-                pageInfo { hasNextPage endCursor } 
-                nodes { ...PrincipalDetails } 
-            }
-        } 
-        fragment PrincipalDetails on CloudResourceV2 { 
-            id name type nativeType deletedAt 
-            graphEntity { id type properties } 
-            hasAccessToSensitiveData hasAdminPrivileges hasHighPrivileges hasSensitiveData 
-            projects { id name slug isFolder } 
-            technology { id icon name categories { id name } description } 
-            cloudAccount { id name cloudProvider externalId } 
-            issueAnalytics { 
-                issueCount informationalSeverityCount lowSeverityCount 
-                mediumSeverityCount highSeverityCount criticalSeverityCount 
-            }
-        }";
+        var query = GraphQlQueries.UsersQuery;
 
         var variables = new {
             first,
@@ -217,12 +200,7 @@ public class WizClient : IDisposable {
     /// <param name="after">The cursor for pagination, if retrieving subsequent pages.</param>
     /// <returns>A tuple containing the projects, whether there's a next page, and the cursor for the next page.</returns>
     private async Task<(List<WizProject> Projects, bool HasNextPage, string? EndCursor)> GetProjectsPageAsync(int first, string? after = null) {
-        const string query = @"query Projects($first: Int, $after: String) {
-            projects(first: $first, after: $after) {
-                pageInfo { hasNextPage endCursor }
-                nodes { id name slug isFolder }
-            }
-        }";
+        const string query = GraphQlQueries.ProjectsQuery;
 
         var variables = new {
             first,


### PR DESCRIPTION
## Summary
- centralize Wiz GraphQL queries in `GraphQlQueries`
- reference query constants from `WizClient`
- showcase the constants in a new example
- verify queries and references via new unit tests

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6888f8fd2e58832e89bea42cb632365e