### PR TITLE
Add async enumerator for projects

### DIFF
--- a/WizCloud.Examples/Samples/StreamingSample.cs
+++ b/WizCloud.Examples/Samples/StreamingSample.cs
@@ -15,5 +15,10 @@ internal static class StreamingSample {
             Console.WriteLine($"Streaming user: {user.Name}");
             break;
         }
+
+        await foreach (var project in client.GetProjectsAsyncEnumerable(pageSize: 1)) {
+            Console.WriteLine($"Streaming project: {project.Name}");
+            break;
+        }
     }
 }

--- a/WizCloud.Tests/GetProjectsAsyncEnumerableTests.cs
+++ b/WizCloud.Tests/GetProjectsAsyncEnumerableTests.cs
@@ -1,0 +1,14 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetProjectsAsyncEnumerableTests {
+    [TestMethod]
+    public void MethodExistsWithCorrectReturnType() {
+        var method = typeof(WizClient).GetMethod("GetProjectsAsyncEnumerable");
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(IAsyncEnumerable<WizProject>), method!.ReturnType);
+    }
+}


### PR DESCRIPTION
## Summary
- support streaming projects from WizClient
- show project streaming in examples
- test for new `GetProjectsAsyncEnumerable` API

## Testing
- `dotnet build WizCloud.sln -c Release`
- `dotnet test WizCloud.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68892faad974832e89756aa925ef857c