### PR TITLE
Add cloud account query to WizClient

### DIFF
--- a/WizCloud.Examples/Program.cs
+++ b/WizCloud.Examples/Program.cs
@@ -8,5 +8,6 @@ internal class Program {
         await StreamingSample.RunAsync();
         await ErrorHandlingSample.RunAsync();
         await GraphQlQueriesSample.RunAsync();
+        await CloudAccountsSample.RunAsync();
     }
 }

--- a/WizCloud.Examples/Samples/CloudAccountsSample.cs
+++ b/WizCloud.Examples/Samples/CloudAccountsSample.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+
+namespace WizCloud.Examples;
+internal static class CloudAccountsSample {
+    public static async Task RunAsync() {
+        var token = Environment.GetEnvironmentVariable("WIZ_SERVICE_ACCOUNT_TOKEN");
+        if (string.IsNullOrEmpty(token)) {
+            Console.WriteLine("WIZ_SERVICE_ACCOUNT_TOKEN environment variable is not set.");
+            return;
+        }
+
+        using var client = new WizClient(token);
+        var accounts = await client.GetCloudAccountsAsync(pageSize: 1);
+        Console.WriteLine($"Cloud accounts sample retrieved {accounts.Count} account(s).");
+        if (accounts.Count > 0) {
+            Console.WriteLine($"First account provider: {accounts[0].CloudProvider}");
+        }
+    }
+}

--- a/WizCloud.Examples/Samples/GraphQlQueriesSample.cs
+++ b/WizCloud.Examples/Samples/GraphQlQueriesSample.cs
@@ -6,6 +6,7 @@ internal static class GraphQlQueriesSample {
     public static Task RunAsync() {
         Console.WriteLine($"Users query length: {GraphQlQueries.UsersQuery.Length}");
         Console.WriteLine($"Projects query length: {GraphQlQueries.ProjectsQuery.Length}");
+        Console.WriteLine($"Cloud accounts query length: {GraphQlQueries.CloudAccountsQuery.Length}");
         return Task.CompletedTask;
     }
 }

--- a/WizCloud.Tests/GetCloudAccountsAsyncTests.cs
+++ b/WizCloud.Tests/GetCloudAccountsAsyncTests.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetCloudAccountsAsyncTests {
+    [TestMethod]
+    public void MethodExistsWithCorrectReturnType() {
+        var method = typeof(WizCloud.WizClient).GetMethod("GetCloudAccountsAsync");
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(Task<List<WizCloud.WizCloudAccount>>), method!.ReturnType);
+    }
+}
+

--- a/WizCloud.Tests/GraphQlQueriesTests.cs
+++ b/WizCloud.Tests/GraphQlQueriesTests.cs
@@ -20,4 +20,12 @@ public sealed class GraphQlQueriesTests {
         Assert.IsNotNull(field);
         Assert.AreEqual(typeof(string), field!.FieldType);
     }
+
+    [TestMethod]
+    public void CloudAccountsQuery_ConstantExists() {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Static;
+        var field = typeof(GraphQlQueries).GetField("CloudAccountsQuery", flags);
+        Assert.IsNotNull(field);
+        Assert.AreEqual(typeof(string), field!.FieldType);
+    }
 }

--- a/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
+++ b/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
@@ -13,5 +13,6 @@ public sealed class WizClientGraphQlQueriesTests {
         var source = File.ReadAllText(filePath);
         StringAssert.Contains(source, "GraphQlQueries.UsersQuery");
         StringAssert.Contains(source, "GraphQlQueries.ProjectsQuery");
+        StringAssert.Contains(source, "GraphQlQueries.CloudAccountsQuery");
     }
 }

--- a/WizCloud/GraphQlQueries.cs
+++ b/WizCloud/GraphQlQueries.cs
@@ -28,10 +28,20 @@ public static class GraphQlQueries {
     /// <summary>
     /// Query for retrieving projects.
     /// </summary>
-    public const string ProjectsQuery = @"query Projects($first: Int, $after: String) {
+        public const string ProjectsQuery = @"query Projects($first: Int, $after: String) {
             projects(first: $first, after: $after) {
                 pageInfo { hasNextPage endCursor }
                 nodes { id name slug isFolder }
+            }
+        }";
+
+    /// <summary>
+    /// Query for retrieving cloud accounts.
+    /// </summary>
+    public const string CloudAccountsQuery = @"query CloudAccounts($first: Int, $after: String) {
+            cloudAccounts(first: $first, after: $after) {
+                pageInfo { hasNextPage endCursor }
+                nodes { id name cloudProvider externalId }
             }
         }";
 }

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -258,6 +258,87 @@ public class WizClient : IDisposable {
     }
 
     /// <summary>
+    /// Retrieves all cloud accounts from Wiz asynchronously.
+    /// </summary>
+    /// <param name="pageSize">The number of cloud accounts to retrieve per page. Defaults to 20.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains a list of all cloud accounts.</returns>
+    public async Task<List<WizCloudAccount>> GetCloudAccountsAsync(int pageSize = 20) {
+        var accounts = new List<WizCloudAccount>();
+        string? endCursor = null;
+        bool hasNextPage = true;
+
+        while (hasNextPage) {
+            var result = await GetCloudAccountsPageAsync(pageSize, endCursor).ConfigureAwait(false);
+            accounts.AddRange(result.Accounts);
+            hasNextPage = result.HasNextPage;
+            endCursor = result.EndCursor;
+        }
+
+        return accounts;
+    }
+
+    /// <summary>
+    /// Retrieves a single page of cloud accounts from the Wiz API.
+    /// </summary>
+    /// <param name="first">The number of cloud accounts to retrieve.</param>
+    /// <param name="after">The cursor for pagination, if retrieving subsequent pages.</param>
+    /// <returns>A tuple containing the cloud accounts, whether there's a next page, and the cursor for the next page.</returns>
+    private async Task<(List<WizCloudAccount> Accounts, bool HasNextPage, string? EndCursor)> GetCloudAccountsPageAsync(int first, string? after = null) {
+        const string query = GraphQlQueries.CloudAccountsQuery;
+
+        var variables = new {
+            first,
+            after
+        };
+
+        var requestBody = new {
+            query,
+            variables
+        };
+
+        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            request.Content = new StringContent(
+                JsonSerializer.Serialize(requestBody),
+                Encoding.UTF8,
+                "application/json"
+            );
+
+            using (var response = await _httpClient.SendAsync(request).ConfigureAwait(false)) {
+                response.EnsureSuccessStatusCode();
+
+                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var jsonResponse = JsonNode.Parse(content);
+
+                if (jsonResponse == null)
+                    throw new InvalidOperationException("Received null response from API");
+
+                var accounts = new List<WizCloudAccount>();
+                var nodes = jsonResponse["data"]?["cloudAccounts"]?["nodes"]?.AsArray();
+
+                if (nodes != null) {
+                    foreach (var node in nodes) {
+                        if (node != null) {
+                            accounts.Add(new WizCloudAccount {
+                                Id = node["id"]?.GetValue<string>() ?? string.Empty,
+                                Name = node["name"]?.GetValue<string>() ?? string.Empty,
+                                CloudProvider = node["cloudProvider"]?.GetValue<string>() ?? string.Empty,
+                                ExternalId = node["externalId"]?.GetValue<string>()
+                            });
+                        }
+                    }
+                }
+
+                var pageInfo = jsonResponse["data"]?["cloudAccounts"]?["pageInfo"];
+                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+                return (accounts, hasNextPage, endCursor);
+            }
+        }
+    }
+
+    /// <summary>
     /// Releases all resources used by the WizClient.
     /// </summary>
     public void Dispose() {


### PR DESCRIPTION
## Summary
- add GraphQl query for cloud accounts
- fetch WizCloudAccount info from WizClient
- showcase the new functionality in examples
- cover new API with unit tests

## Testing
- `dotnet test --no-build`
- `dotnet build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_68892fb3db3c832e8cb921c2ea217a85