### PR TITLE
Add automatic token refresh

### DIFF
--- a/WizCloud.Tests/TokenRefreshTests.cs
+++ b/WizCloud.Tests/TokenRefreshTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class TokenRefreshTests {
+    [TestMethod]
+    public void WizClient_RefreshesTokenOnUnauthorized() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
+        var source = File.ReadAllText(filePath);
+        StringAssert.Contains(source, "AcquireTokenAsync");
+        StringAssert.Contains(source, "Unauthorized");
+    }
+}
+


### PR DESCRIPTION
## Summary
- add optional client credentials to `WizClient`
- implement token refresh on unauthorized responses
- add unit test to assert token refresh logic exists

## Testing
- `dotnet test WizCloud.sln -c Release`
- `dotnet build WizCloud.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68892fc1ae5c832e955a757cbba94c25