### PR TITLE
Introduce typed enums for Wiz models

### DIFF
--- a/Module/Examples/GetUsers.ps1
+++ b/Module/Examples/GetUsers.ps1
@@ -19,7 +19,7 @@ $users | Select-Object Name, Type, HasAdminPrivileges, HasHighPrivileges | Forma
 $users = Get-WizUser -PageSize 50
 
 # Example 3: Get users from a specific region
-$usUsers = Get-WizUser -Region "us1" -Token "your-us-token"
+$usUsers = Get-WizUser -Region [WizRegion]::US1 -Token "your-us-token"
 
 # Example 4: Filter users with admin privileges
 $adminUsers = Get-WizUser | Where-Object { $_.HasAdminPrivileges -eq $true }

--- a/WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs
@@ -50,8 +50,7 @@ public class CmdletConnectWiz : AsyncPSCmdlet {
     /// <para type="description">The Wiz region to connect to. Default is 'eu17'.</para>
     /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "The Wiz region to connect to (e.g., 'eu17', 'us1', 'us2').")]
-    [ValidateNotNullOrEmpty]
-    public string Region { get; set; } = "eu17";
+    public WizRegion Region { get; set; } = WizRegion.EU17;
 
     /// <summary>
     /// <para type="description">Test the connection to Wiz.</para>
@@ -71,8 +70,7 @@ public class CmdletConnectWiz : AsyncPSCmdlet {
 
                 if (string.IsNullOrEmpty(Token) && !string.IsNullOrEmpty(ClientId) && !string.IsNullOrEmpty(ClientSecret)) {
                     WriteVerbose("Retrieving token using client credentials");
-                    var regionEnum = WizRegionHelper.FromString(Region);
-                    Token = await WizAuthentication.AcquireTokenAsync(ClientId!, ClientSecret!, regionEnum);
+                    Token = await WizAuthentication.AcquireTokenAsync(ClientId!, ClientSecret!, Region);
                 }
 
                 if (string.IsNullOrEmpty(Token)) {

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
@@ -36,8 +36,7 @@ public class CmdletGetWizUser : AsyncPSCmdlet {
     /// <para type="description">The Wiz region to connect to. If not provided, uses the region from Connect-Wiz or defaults to 'eu17'.</para>
     /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "The Wiz region to connect to (e.g., 'eu17', 'us1', 'us2').")]
-    [ValidateNotNullOrEmpty]
-    public string? Region { get; set; }
+    public WizRegion? Region { get; set; }
 
     /// <summary>
     /// <para type="description">The number of users to retrieve per page. Default is 20.</para>
@@ -69,12 +68,12 @@ public class CmdletGetWizUser : AsyncPSCmdlet {
             }
 
             // Use stored region if not provided
-            if (string.IsNullOrEmpty(Region)) {
-                Region = ModuleInitialization.DefaultRegion ?? "eu17";
+            if (Region is null) {
+                Region = ModuleInitialization.DefaultRegion;
                 WriteVerbose($"Using region: {Region}");
             }
 
-            _wizClient = new WizClient(Token!, Region ?? "eu17");
+            _wizClient = new WizClient(Token!, Region.Value);
             WriteVerbose($"Connected to Wiz region: {Region}");
         } catch (HttpRequestException ex) {
             WriteError(new ErrorRecord(

--- a/WizCloud.PowerShell/ModuleInitialization.cs
+++ b/WizCloud.PowerShell/ModuleInitialization.cs
@@ -5,23 +5,20 @@ namespace WizCloud.PowerShell;
 /// Module initialization and cleanup
 /// </summary>
 public class ModuleInitialization : IModuleAssemblyInitializer, IModuleAssemblyCleanup {
-    private static string? _defaultToken = null;
-    private static string? _defaultRegion = "eu17";
-
     /// <summary>
     /// Gets or sets the default Wiz token for the session
     /// </summary>
     public static string? DefaultToken {
-        get => _defaultToken;
-        set => _defaultToken = value;
+        get => WizSession.DefaultToken;
+        set => WizSession.DefaultToken = value;
     }
 
     /// <summary>
     /// Gets or sets the default Wiz region for the session
     /// </summary>
-    public static string? DefaultRegion {
-        get => _defaultRegion;
-        set => _defaultRegion = value;
+    public static WizRegion DefaultRegion {
+        get => WizSession.DefaultRegion;
+        set => WizSession.DefaultRegion = value;
     }
 
     /// <summary>
@@ -36,7 +33,7 @@ public class ModuleInitialization : IModuleAssemblyInitializer, IModuleAssemblyC
 
         var envRegion = System.Environment.GetEnvironmentVariable("WIZ_REGION");
         if (!string.IsNullOrEmpty(envRegion)) {
-            DefaultRegion = envRegion;
+            DefaultRegion = WizRegionHelper.FromString(envRegion);
         }
     }
 
@@ -45,6 +42,6 @@ public class ModuleInitialization : IModuleAssemblyInitializer, IModuleAssemblyC
     /// </summary>
     public void OnRemove(PSModuleInfo psModuleInfo) {
         DefaultToken = null;
-        DefaultRegion = "eu17";
+        DefaultRegion = WizRegion.EU17;
     }
 }

--- a/WizCloud.Tests/WizClientConstructorTests.cs
+++ b/WizCloud.Tests/WizClientConstructorTests.cs
@@ -3,23 +3,6 @@ using WizCloud;
 namespace WizCloud.Tests;
 [TestClass]
 public sealed class WizClientConstructorTests {
-    [TestMethod]
-    public void Constructor_WithNullRegionString_ThrowsArgumentNullException() {
-        Assert.ThrowsException<ArgumentNullException>(() => new WizClient("token", (string)null!));
-    }
-
-    [TestMethod]
-    public void Constructor_WithNullRegionEnum_ThrowsArgumentNullException() {
-        Assert.ThrowsException<ArgumentNullException>(() => new WizClient("token", (WizRegion?)null));
-    }
-
-    [DataTestMethod]
-    [DataRow("")]
-    [DataRow(" ")]
-    [DataRow("   ")]
-    public void Constructor_WithEmptyOrWhitespaceRegionString_ThrowsArgumentException(string region) {
-        Assert.ThrowsException<ArgumentException>(() => new WizClient("token", region));
-    }
 
     [TestMethod]
     public void HttpClient_IsSharedAcrossInstances() {
@@ -32,5 +15,14 @@ public sealed class WizClientConstructorTests {
         Assert.IsNotNull(sharedInstance);
         var secondShared = firstClientField.GetValue(null);
         Assert.AreSame(sharedInstance, secondShared);
+    }
+
+    [TestMethod]
+    public void Constructor_SetsRegionAndEndpoint() {
+        using var client = new WizClient("token", WizRegion.US1);
+        var endpointField = typeof(WizClient).GetField("_apiEndpoint", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.IsNotNull(endpointField);
+        string value = (string)endpointField!.GetValue(client)!;
+        StringAssert.Contains(value, "us1");
     }
 }

--- a/WizCloud.Tests/WizUserTests.cs
+++ b/WizCloud.Tests/WizUserTests.cs
@@ -68,7 +68,7 @@ public sealed class WizUserTests {
         Assert.AreEqual("1", user.Id);
         Assert.AreEqual("John Doe", user.Name);
         Assert.AreEqual(WizUserType.USER_ACCOUNT, user.Type);
-        Assert.AreEqual("AADUser", user.NativeType);
+        Assert.AreEqual(WizNativeType.AADUser, user.NativeType);
         Assert.AreEqual(DateTime.Parse("2024-05-01T00:00:00Z"), user.DeletedAt);
 
         Assert.IsTrue(user.HasAccessToSensitiveData);
@@ -77,7 +77,7 @@ public sealed class WizUserTests {
         Assert.IsTrue(user.HasSensitiveData);
 
         Assert.AreEqual("ge1", user.GraphEntityId);
-        Assert.AreEqual("user", user.GraphEntityType);
+        Assert.AreEqual(WizGraphEntityType.USER, user.GraphEntityType);
         Assert.AreEqual("value1", user.GraphEntityProperties["prop1"]);
 
         Assert.AreEqual(1, user.Projects.Count);
@@ -99,7 +99,7 @@ public sealed class WizUserTests {
         Assert.IsNotNull(user.CloudAccount);
         Assert.AreEqual("acc1", user.CloudAccount!.Id);
         Assert.AreEqual("Account 1", user.CloudAccount!.Name);
-        Assert.AreEqual("AWS", user.CloudAccount!.CloudProvider);
+        Assert.AreEqual(WizCloudProvider.AWS, user.CloudAccount!.CloudProvider);
         Assert.AreEqual("123", user.CloudAccount!.ExternalId);
 
         Assert.IsNotNull(user.IssueAnalytics);

--- a/WizCloud/Enums/WizGraphEntityType.cs
+++ b/WizCloud/Enums/WizGraphEntityType.cs
@@ -1,0 +1,25 @@
+namespace WizCloud;
+/// <summary>
+/// Represents the graph entity types returned by the Wiz API.
+/// </summary>
+public enum WizGraphEntityType {
+    /// <summary>
+    /// A user entity.
+    /// </summary>
+    USER,
+
+    /// <summary>
+    /// A service account entity.
+    /// </summary>
+    SERVICE_ACCOUNT,
+
+    /// <summary>
+    /// A group entity.
+    /// </summary>
+    GROUP,
+
+    /// <summary>
+    /// An access key entity.
+    /// </summary>
+    ACCESS_KEY
+}

--- a/WizCloud/Enums/WizNativeType.cs
+++ b/WizCloud/Enums/WizNativeType.cs
@@ -1,0 +1,25 @@
+namespace WizCloud;
+/// <summary>
+/// Represents the native identity type in the cloud provider.
+/// </summary>
+public enum WizNativeType {
+    /// <summary>
+    /// Azure Active Directory user account.
+    /// </summary>
+    AADUser,
+
+    /// <summary>
+    /// Azure Active Directory group.
+    /// </summary>
+    AADGroup,
+
+    /// <summary>
+    /// AWS IAM user.
+    /// </summary>
+    AWSIamUser,
+
+    /// <summary>
+    /// Other or unknown type.
+    /// </summary>
+    UNKNOWN
+}

--- a/WizCloud/Helpers/WizSession.cs
+++ b/WizCloud/Helpers/WizSession.cs
@@ -1,0 +1,24 @@
+namespace WizCloud;
+/// <summary>
+/// Provides session level defaults for Wiz operations.
+/// </summary>
+public static class WizSession {
+    private static string? _defaultToken;
+    private static WizRegion _defaultRegion = WizRegion.EU17;
+
+    /// <summary>
+    /// Gets or sets the default Wiz token for the session.
+    /// </summary>
+    public static string? DefaultToken {
+        get => _defaultToken;
+        set => _defaultToken = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the default Wiz region for the session.
+    /// </summary>
+    public static WizRegion DefaultRegion {
+        get => _defaultRegion;
+        set => _defaultRegion = value;
+    }
+}

--- a/WizCloud/Models/WizCloudAccount.cs
+++ b/WizCloud/Models/WizCloudAccount.cs
@@ -16,7 +16,7 @@ public class WizCloudAccount {
     /// <summary>
     /// Gets or sets the cloud provider (e.g., AWS, Azure, GCP).
     /// </summary>
-    public string CloudProvider { get; set; } = string.Empty;
+    public WizCloudProvider CloudProvider { get; set; } = WizCloudProvider.AWS;
 
     /// <summary>
     /// Gets or sets the external identifier for the cloud account (e.g., AWS Account ID).

--- a/WizCloud/Models/WizUser.cs
+++ b/WizCloud/Models/WizUser.cs
@@ -25,7 +25,7 @@ public class WizUser {
     /// <summary>
     /// Gets or sets the native type in the cloud provider.
     /// </summary>
-    public string? NativeType { get; set; }
+    public WizNativeType? NativeType { get; set; }
 
     /// <summary>
     /// Gets or sets the date and time when the user was deleted, if applicable.
@@ -42,7 +42,7 @@ public class WizUser {
     /// <summary>
     /// Gets or sets the graph entity type.
     /// </summary>
-    public string? GraphEntityType { get; set; }
+    public WizGraphEntityType? GraphEntityType { get; set; }
 
     /// <summary>
     /// Gets or sets additional properties from the graph entity.
@@ -103,7 +103,9 @@ public class WizUser {
             Id = json["id"]?.GetValue<string>() ?? string.Empty,
             Name = json["name"]?.GetValue<string>() ?? string.Empty,
             Type = Enum.TryParse(json["type"]?.GetValue<string>(), true, out WizUserType tmpType) ? tmpType : WizUserType.USER_ACCOUNT,
-            NativeType = json["nativeType"]?.GetValue<string>(),
+            NativeType = Enum.TryParse(json["nativeType"]?.GetValue<string>(), true, out WizNativeType tmpNative)
+                ? tmpNative
+                : null,
             DeletedAt = json["deletedAt"]?.GetValue<DateTime?>()?.ToLocalTime(),
 
             HasAccessToSensitiveData = json["hasAccessToSensitiveData"]?.GetValue<bool>() ?? false,
@@ -119,7 +121,9 @@ public class WizUser {
         var graphEntity = json["graphEntity"] as JsonObject;
         if (graphEntity != null) {
             user.GraphEntityId = graphEntity["id"]?.GetValue<string>();
-            user.GraphEntityType = graphEntity["type"]?.GetValue<string>();
+            var geTypeStr = graphEntity["type"]?.GetValue<string>();
+            if (Enum.TryParse(geTypeStr, true, out WizGraphEntityType tmpGeType))
+                user.GraphEntityType = tmpGeType;
 
             var properties = graphEntity["properties"] as JsonObject;
             if (properties != null) {
@@ -174,7 +178,9 @@ public class WizUser {
             user.CloudAccount = new WizCloudAccount {
                 Id = cloudAccount["id"]?.GetValue<string>() ?? string.Empty,
                 Name = cloudAccount["name"]?.GetValue<string>() ?? string.Empty,
-                CloudProvider = cloudAccount["cloudProvider"]?.GetValue<string>() ?? string.Empty,
+                CloudProvider = Enum.TryParse(cloudAccount["cloudProvider"]?.GetValue<string>(), true, out WizCloudProvider tmpProvider)
+                    ? tmpProvider
+                    : WizCloudProvider.AWS,
                 ExternalId = cloudAccount["externalId"]?.GetValue<string>()
             };
         }

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -31,46 +31,20 @@ public class WizClient : IDisposable {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="WizClient"/> class with a token and region string.
+    /// Initializes a new instance of the <see cref="WizClient"/> class.
     /// </summary>
     /// <param name="token">The Wiz service account token for authentication.</param>
-    /// <param name="region">The Wiz region identifier (e.g., "eu17", "us1"). Defaults to "eu17".</param>
+    /// <param name="region">The Wiz region enumeration value. Defaults to <see cref="WizRegion.EU17"/>.</param>
     /// <exception cref="ArgumentException">Thrown when the token is null or empty.</exception>
-    public WizClient(string token, string region = "eu17", string? clientId = null, string? clientSecret = null) {
+    public WizClient(string token, WizRegion region = WizRegion.EU17, string? clientId = null, string? clientSecret = null) {
         if (string.IsNullOrWhiteSpace(token))
             throw new ArgumentException("Token cannot be null or empty", nameof(token));
-
-        if (region is null)
-            throw new ArgumentNullException(nameof(region));
-
-        if (string.IsNullOrWhiteSpace(region))
-            throw new ArgumentException("Region cannot be empty or whitespace", nameof(region));
 
         _token = token;
         _clientId = clientId;
         _clientSecret = clientSecret;
-        _region = WizRegionHelper.FromString(region);
-        _apiEndpoint = $"https://api.{region}.app.wiz.io/graphql";
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="WizClient"/> class with a token and region enum.
-    /// </summary>
-    /// <param name="token">The Wiz service account token for authentication.</param>
-    /// <param name="region">The Wiz region enumeration value.</param>
-    /// <exception cref="ArgumentException">Thrown when the token is null or empty.</exception>
-    public WizClient(string token, WizRegion? region, string? clientId = null, string? clientSecret = null) {
-        if (string.IsNullOrWhiteSpace(token))
-            throw new ArgumentException("Token cannot be null or empty", nameof(token));
-
-        if (region is null)
-            throw new ArgumentNullException(nameof(region));
-
-        var regionString = WizRegionHelper.ToApiString(region.Value);
-        _token = token;
-        _clientId = clientId;
-        _clientSecret = clientSecret;
-        _region = region.Value;
+        _region = region;
+        var regionString = WizRegionHelper.ToApiString(region);
         _apiEndpoint = $"https://api.{regionString}.app.wiz.io/graphql";
     }
 
@@ -395,7 +369,9 @@ public class WizClient : IDisposable {
                             accounts.Add(new WizCloudAccount {
                                 Id = node["id"]?.GetValue<string>() ?? string.Empty,
                                 Name = node["name"]?.GetValue<string>() ?? string.Empty,
-                                CloudProvider = node["cloudProvider"]?.GetValue<string>() ?? string.Empty,
+                                CloudProvider = Enum.TryParse(node["cloudProvider"]?.GetValue<string>(), true, out WizCloudProvider provider)
+                                    ? provider
+                                    : WizCloudProvider.AWS,
                                 ExternalId = node["externalId"]?.GetValue<string>()
                             });
                         }


### PR DESCRIPTION
## Summary
- add `WizGraphEntityType` and `WizNativeType` enums
- type `WizCloudAccount.CloudProvider` with `WizCloudProvider`
- move default token/region storage to new `WizSession` in library
- update cmdlets and `WizClient` to use `WizRegion` enum
- adjust examples and tests for enum usage

## Testing
- `dotnet test WizCloud.Tests/WizCloud.Tests.csproj --verbosity minimal`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path Module/Tests"`

------
https://chatgpt.com/codex/tasks/task_e_6889e2befa2c832e957d07bb1adfa2a0