### PR TITLE
Update authentication flow

### DIFF
--- a/Module/Examples/GetUsers.ps1
+++ b/Module/Examples/GetUsers.ps1
@@ -2,11 +2,8 @@
 Import-Module .\WizCloud.psd1 -Force
 
 # Example 1: Connect to Wiz and get all users
-# First, set your token as an environment variable or pass it directly
-# $env:WIZ_SERVICE_ACCOUNT_TOKEN = "your-token-here"
-
-# Connect to Wiz (uses environment variable if token not provided)
-Connect-Wiz -TestConnection
+# Provide client credentials to acquire a token and store it for the session
+Connect-Wiz -ClientId "clientId" -ClientSecret "clientSecret" -TestConnection
 
 # Get all users
 $users = Get-WizUser

--- a/README.MD
+++ b/README.MD
@@ -30,8 +30,8 @@ To run unit tests:
 ```csharp
 using WizCloud;
 
-var token = Environment.GetEnvironmentVariable("WIZ_SERVICE_ACCOUNT_TOKEN");
-using var client = new WizClient(token!, WizRegion.EU17);
+var token = await WizAuthentication.AcquireTokenAsync("clientId", "clientSecret", WizRegion.EU17);
+using var client = new WizClient(token, WizRegion.EU17);
 var projects = await client.GetProjectsAsync();
 Console.WriteLine($"Retrieved {projects.Count} projects");
 ```
@@ -42,8 +42,8 @@ Console.WriteLine($"Retrieved {projects.Count} projects");
 # Import the module from the repository
 Import-Module ./Module/WizCloud.psd1 -Force
 
-# Connect using an environment variable or provide a token
-Connect-Wiz -TestConnection
+# Connect using client credentials
+Connect-Wiz -ClientId "clientId" -ClientSecret "clientSecret" -TestConnection
 
 # Retrieve users
 Get-WizUser -PageSize 50 | Select-Object Name, Type

--- a/WizCloud.Examples/Samples/ClientCredentialSample.cs
+++ b/WizCloud.Examples/Samples/ClientCredentialSample.cs
@@ -5,14 +5,7 @@ using WizCloud;
 namespace WizCloud.Examples;
 internal static class ClientCredentialSample {
     public static async Task RunAsync() {
-        var clientId = Environment.GetEnvironmentVariable("WIZ_CLIENT_ID");
-        var clientSecret = Environment.GetEnvironmentVariable("WIZ_CLIENT_SECRET");
-        if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret)) {
-            Console.WriteLine("WIZ_CLIENT_ID or WIZ_CLIENT_SECRET environment variables are not set.");
-            return;
-        }
-
-        var token = await WizAuthentication.AcquireTokenAsync(clientId, clientSecret);
+        var token = await WizAuthentication.AcquireTokenAsync("clientId", "clientSecret");
         using var client = new WizClient(token);
         var users = await client.GetUsersAsync(pageSize: 1);
         Console.WriteLine($"Client credentials sample retrieved {users.Count} user(s).");

--- a/WizCloud.Examples/Samples/CloudAccountsSample.cs
+++ b/WizCloud.Examples/Samples/CloudAccountsSample.cs
@@ -4,12 +4,7 @@ using System.Threading.Tasks;
 namespace WizCloud.Examples;
 internal static class CloudAccountsSample {
     public static async Task RunAsync() {
-        var token = Environment.GetEnvironmentVariable("WIZ_SERVICE_ACCOUNT_TOKEN");
-        if (string.IsNullOrEmpty(token)) {
-            Console.WriteLine("WIZ_SERVICE_ACCOUNT_TOKEN environment variable is not set.");
-            return;
-        }
-
+        var token = await WizAuthentication.AcquireTokenAsync("clientId", "clientSecret");
         using var client = new WizClient(token);
         var accounts = await client.GetCloudAccountsAsync(pageSize: 1);
         Console.WriteLine($"Cloud accounts sample retrieved {accounts.Count} account(s).");

--- a/WizCloud.Examples/Samples/MultiClientSample.cs
+++ b/WizCloud.Examples/Samples/MultiClientSample.cs
@@ -4,12 +4,7 @@ using System.Threading.Tasks;
 namespace WizCloud.Examples;
 internal static class MultiClientSample {
     public static async Task RunAsync() {
-        var token = Environment.GetEnvironmentVariable("WIZ_SERVICE_ACCOUNT_TOKEN");
-        if (string.IsNullOrEmpty(token)) {
-            Console.WriteLine("WIZ_SERVICE_ACCOUNT_TOKEN environment variable is not set.");
-            return;
-        }
-
+        var token = await WizAuthentication.AcquireTokenAsync("clientId", "clientSecret");
         using var first = new WizClient(token);
         using var second = new WizClient(token);
         var users1 = await first.GetUsersAsync(pageSize: 1);

--- a/WizCloud.Examples/Samples/StreamingSample.cs
+++ b/WizCloud.Examples/Samples/StreamingSample.cs
@@ -4,12 +4,7 @@ using System.Threading.Tasks;
 namespace WizCloud.Examples;
 internal static class StreamingSample {
     public static async Task RunAsync() {
-        var token = Environment.GetEnvironmentVariable("WIZ_SERVICE_ACCOUNT_TOKEN");
-        if (string.IsNullOrEmpty(token)) {
-            Console.WriteLine("WIZ_SERVICE_ACCOUNT_TOKEN environment variable is not set.");
-            return;
-        }
-
+        var token = await WizAuthentication.AcquireTokenAsync("clientId", "clientSecret");
         using var client = new WizClient(token);
         await foreach (var user in client.GetUsersAsyncEnumerable(pageSize: 1)) {
             Console.WriteLine($"Streaming user: {user.Name}");

--- a/WizCloud.Examples/Samples/TokenAuthSample.cs
+++ b/WizCloud.Examples/Samples/TokenAuthSample.cs
@@ -5,12 +5,7 @@ using WizCloud;
 namespace WizCloud.Examples;
 internal static class TokenAuthSample {
     public static async Task RunAsync() {
-        var token = Environment.GetEnvironmentVariable("WIZ_SERVICE_ACCOUNT_TOKEN");
-        if (string.IsNullOrEmpty(token)) {
-            Console.WriteLine("WIZ_SERVICE_ACCOUNT_TOKEN environment variable is not set.");
-            return;
-        }
-
+        var token = await WizAuthentication.AcquireTokenAsync("clientId", "clientSecret");
         using var client = new WizClient(token);
         var users = await client.GetUsersAsync(pageSize: 1);
         Console.WriteLine($"Token auth sample retrieved {users.Count} user(s).");

--- a/WizCloud.PowerShell/Cmdlets/CmdletDisconnectWiz.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletDisconnectWiz.cs
@@ -1,0 +1,24 @@
+using System.Management.Automation;
+
+namespace WizCloud.PowerShell;
+
+/// <summary>
+/// <para type="synopsis">Clears Wiz authentication from the current session.</para>
+/// <para type="description">The Disconnect-Wiz cmdlet removes stored authentication and client credentials from the session.</para>
+/// <example>
+/// <para>Disconnect from Wiz:</para>
+/// <code>Disconnect-Wiz</code>
+/// </example>
+/// </summary>
+[Cmdlet(VerbsCommunications.Disconnect, "Wiz")]
+[OutputType(typeof(bool))]
+public sealed class CmdletDisconnectWiz : PSCmdlet {
+    /// <inheritdoc/>
+    protected override void ProcessRecord() {
+        ModuleInitialization.DefaultToken = null;
+        ModuleInitialization.DefaultClientId = null;
+        ModuleInitialization.DefaultClientSecret = null;
+        ModuleInitialization.DefaultRegion = WizRegion.EU17;
+        WriteObject(true);
+    }
+}

--- a/WizCloud.PowerShell/ModuleInitialization.cs
+++ b/WizCloud.PowerShell/ModuleInitialization.cs
@@ -14,6 +14,22 @@ public class ModuleInitialization : IModuleAssemblyInitializer, IModuleAssemblyC
     }
 
     /// <summary>
+    /// Gets or sets the default Wiz client id for the session
+    /// </summary>
+    public static string? DefaultClientId {
+        get => WizSession.DefaultClientId;
+        set => WizSession.DefaultClientId = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the default Wiz client secret for the session
+    /// </summary>
+    public static string? DefaultClientSecret {
+        get => WizSession.DefaultClientSecret;
+        set => WizSession.DefaultClientSecret = value;
+    }
+
+    /// <summary>
     /// Gets or sets the default Wiz region for the session
     /// </summary>
     public static WizRegion DefaultRegion {
@@ -25,16 +41,7 @@ public class ModuleInitialization : IModuleAssemblyInitializer, IModuleAssemblyC
     /// Called when the module is imported
     /// </summary>
     public void OnImport() {
-        // Check for environment variable on import
-        var envToken = System.Environment.GetEnvironmentVariable("WIZ_SERVICE_ACCOUNT_TOKEN");
-        if (!string.IsNullOrEmpty(envToken)) {
-            DefaultToken = envToken;
-        }
-
-        var envRegion = System.Environment.GetEnvironmentVariable("WIZ_REGION");
-        if (!string.IsNullOrEmpty(envRegion)) {
-            DefaultRegion = WizRegionHelper.FromString(envRegion);
-        }
+        // Nothing to do on import
     }
 
     /// <summary>
@@ -42,6 +49,8 @@ public class ModuleInitialization : IModuleAssemblyInitializer, IModuleAssemblyC
     /// </summary>
     public void OnRemove(PSModuleInfo psModuleInfo) {
         DefaultToken = null;
+        DefaultClientId = null;
+        DefaultClientSecret = null;
         DefaultRegion = WizRegion.EU17;
     }
 }

--- a/WizCloud.Tests/ConnectWizCmdletTests.cs
+++ b/WizCloud.Tests/ConnectWizCmdletTests.cs
@@ -1,0 +1,25 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class ConnectWizCmdletTests {
+    [TestMethod]
+    public void ConnectCmdlet_DoesNotUseTokenEnvironmentVariable() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud.PowerShell", "Cmdlets", "CmdletConnectWiz.cs");
+        var source = File.ReadAllText(filePath);
+        Assert.IsFalse(source.Contains("WIZ_SERVICE_ACCOUNT_TOKEN"));
+    }
+
+    [TestMethod]
+    public void DisconnectCmdlet_Exists() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud.PowerShell", "Cmdlets", "CmdletDisconnectWiz.cs");
+        Assert.IsTrue(File.Exists(filePath));
+        var source = File.ReadAllText(filePath);
+        StringAssert.Contains(source, "Disconnect, \"Wiz\"");
+    }
+}

--- a/WizCloud/Helpers/WizSession.cs
+++ b/WizCloud/Helpers/WizSession.cs
@@ -4,6 +4,8 @@ namespace WizCloud;
 /// </summary>
 public static class WizSession {
     private static string? _defaultToken;
+    private static string? _defaultClientId;
+    private static string? _defaultClientSecret;
     private static WizRegion _defaultRegion = WizRegion.EU17;
 
     /// <summary>
@@ -12,6 +14,22 @@ public static class WizSession {
     public static string? DefaultToken {
         get => _defaultToken;
         set => _defaultToken = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the default Wiz client id for the session.
+    /// </summary>
+    public static string? DefaultClientId {
+        get => _defaultClientId;
+        set => _defaultClientId = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the default Wiz client secret for the session.
+    /// </summary>
+    public static string? DefaultClientSecret {
+        get => _defaultClientSecret;
+        set => _defaultClientSecret = value;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- default to client credentials instead of service account token
- clear stored credentials with new `Disconnect-Wiz` cmdlet
- drop token environment variable references in examples and docs
- add tests ensuring environment variable isn't used

## Testing
- `dotnet build WizCloud.sln -c Release`
- `dotnet test WizCloud.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6889ed57d6d0832ebb62e51f0d473061