### PR TITLE
Fix token refresh for cloud accounts

### DIFF
--- a/WizCloud.Tests/TokenRefreshTests.cs
+++ b/WizCloud.Tests/TokenRefreshTests.cs
@@ -14,5 +14,16 @@ public sealed class TokenRefreshTests {
         StringAssert.Contains(source, "AcquireTokenAsync");
         StringAssert.Contains(source, "Unauthorized");
     }
+
+    [TestMethod]
+    public void GetCloudAccounts_UsesSendWithRefreshAsync() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
+        var source = File.ReadAllText(filePath);
+        var index = source.IndexOf("GetCloudAccountsPageAsync", StringComparison.Ordinal);
+        Assert.IsTrue(index >= 0, "GetCloudAccountsPageAsync method not found");
+        var callIndex = source.IndexOf("SendWithRefreshAsync", index, StringComparison.Ordinal);
+        Assert.IsTrue(callIndex >= 0, "SendWithRefreshAsync not used in GetCloudAccountsPageAsync");
+    }
 }
 

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -351,7 +351,7 @@ public class WizClient : IDisposable {
                 "application/json"
             );
 
-            using (var response = await _httpClient.SendAsync(request).ConfigureAwait(false)) {
+            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
                 response.EnsureSuccessStatusCode();
 
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- ensure token refreshing is used for cloud account requests
- check that GetCloudAccountsPageAsync uses SendWithRefreshAsync

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688a5a4b79f8832e85fde4a7be9f486a