### PR TITLE
Ensure cmdlet passes client credentials for token refresh

### DIFF
--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
@@ -73,7 +73,12 @@ public class CmdletGetWizUser : AsyncPSCmdlet {
                 WriteVerbose($"Using region: {Region}");
             }
 
-            _wizClient = new WizClient(Token!, Region.Value);
+            var clientId = ModuleInitialization.DefaultClientId;
+            var clientSecret = ModuleInitialization.DefaultClientSecret;
+
+            _wizClient = !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret)
+                ? new WizClient(Token!, Region.Value, clientId, clientSecret)
+                : new WizClient(Token!, Region.Value);
             WriteVerbose($"Connected to Wiz region: {Region}");
         } catch (HttpRequestException ex) {
             WriteError(new ErrorRecord(

--- a/WizCloud.Tests/TokenRefreshTests.cs
+++ b/WizCloud.Tests/TokenRefreshTests.cs
@@ -25,5 +25,18 @@ public sealed class TokenRefreshTests {
         var callIndex = source.IndexOf("SendWithRefreshAsync", index, StringComparison.Ordinal);
         Assert.IsTrue(callIndex >= 0, "SendWithRefreshAsync not used in GetCloudAccountsPageAsync");
     }
+
+    [TestMethod]
+    public void GetWizUserCmdlet_PassesClientCredentials() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud.PowerShell", "Cmdlets", "CmdletGetWizUser.cs");
+        var source = File.ReadAllText(filePath);
+        StringAssert.Contains(source, "ModuleInitialization.DefaultClientId");
+        StringAssert.Contains(source, "ModuleInitialization.DefaultClientSecret");
+        var ctorIndex = source.IndexOf("new WizClient", StringComparison.Ordinal);
+        Assert.IsTrue(ctorIndex >= 0, "WizClient constructor call not found");
+        var paramIndex = source.IndexOf("clientId, clientSecret", ctorIndex, StringComparison.Ordinal);
+        Assert.IsTrue(paramIndex >= 0, "Client credentials not supplied to WizClient constructor");
+    }
 }
 


### PR DESCRIPTION
## Summary
- use stored client id and secret in `CmdletGetWizUser`
- test that `Get-WizUser` cmdlet passes client credentials to `WizClient`

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688b46a5a478832e959437a721791352