### PR TITLE
Add async interfaces package for older frameworks

### DIFF
--- a/WizCloud/WizCloud.csproj
+++ b/WizCloud/WizCloud.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
## Summary
- include Microsoft.Bcl.AsyncInterfaces for `netstandard2.0` and `net472`
- ensure `net8.0` remains untouched

## Testing
- `dotnet build WizCloud.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688b4696a098832eb05e649beb701c6d