### PR TITLE
Improve GetUsers async error handling

### DIFF
--- a/WizCloud.Tests/GetUsersAsyncEnumerableTests.cs
+++ b/WizCloud.Tests/GetUsersAsyncEnumerableTests.cs
@@ -14,4 +14,16 @@ public sealed class GetUsersAsyncEnumerableTests {
         Assert.IsNotNull(method);
         Assert.AreEqual(typeof(IAsyncEnumerable<WizUser>), method.ReturnType);
     }
+
+    [TestMethod]
+    public void MethodContainsErrorHandling() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
+        var source = File.ReadAllText(filePath);
+        var index = source.IndexOf("GetUsersAsyncEnumerable", StringComparison.Ordinal);
+        Assert.IsTrue(index >= 0, "GetUsersAsyncEnumerable method not found");
+        var snippet = source.Substring(index, Math.Min(800, source.Length - index));
+        StringAssert.Contains(snippet, "catch (HttpRequestException)");
+        StringAssert.Contains(snippet, "yield break");
+    }
 }

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -119,7 +119,12 @@ public class WizClient : IDisposable {
         bool hasNextPage = true;
 
         while (!cancellationToken.IsCancellationRequested && hasNextPage) {
-            var result = await GetUsersPageAsync(pageSize, endCursor).ConfigureAwait(false);
+            (List<WizUser> Users, bool HasNextPage, string? EndCursor) result;
+            try {
+                result = await GetUsersPageAsync(pageSize, endCursor).ConfigureAwait(false);
+            } catch (HttpRequestException) {
+                yield break;
+            }
 
             foreach (var user in result.Users) {
                 if (cancellationToken.IsCancellationRequested)
@@ -194,7 +199,7 @@ public class WizClient : IDisposable {
                 bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
                 string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
 
-                return (users, hasNextPage, endCursor);
+                return (users ?? new List<WizUser>(), hasNextPage, endCursor);
             }
         }
     }


### PR DESCRIPTION
## Summary
- prevent null collection returns in GetUsersPageAsync
- stop enumeration on HttpRequestException in GetUsersAsyncEnumerable
- verify error handling via new unit test

## Testing
- `dotnet build WizCloud.sln -c Release`
- `dotnet test -c Release`


------
https://chatgpt.com/codex/tasks/task_e_688b8a4eb8c8832e9740ae93a3b60ce3