### PR TITLE
Fix GetUsersAsyncEnumerable exception handling

### DIFF
--- a/WizCloud.Tests/GetUsersAsyncEnumerableTests.cs
+++ b/WizCloud.Tests/GetUsersAsyncEnumerableTests.cs
@@ -16,14 +16,13 @@ public sealed class GetUsersAsyncEnumerableTests {
     }
 
     [TestMethod]
-    public void MethodContainsErrorHandling() {
+    public void MethodDoesNotSuppressHttpRequestExceptions() {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
         var source = File.ReadAllText(filePath);
         var index = source.IndexOf("GetUsersAsyncEnumerable", StringComparison.Ordinal);
         Assert.IsTrue(index >= 0, "GetUsersAsyncEnumerable method not found");
         var snippet = source.Substring(index, Math.Min(800, source.Length - index));
-        StringAssert.Contains(snippet, "catch (HttpRequestException)");
-        StringAssert.Contains(snippet, "yield break");
+        Assert.IsFalse(snippet.Contains("catch (HttpRequestException)"));
     }
 }

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -119,12 +119,8 @@ public class WizClient : IDisposable {
         bool hasNextPage = true;
 
         while (!cancellationToken.IsCancellationRequested && hasNextPage) {
-            (List<WizUser> Users, bool HasNextPage, string? EndCursor) result;
-            try {
-                result = await GetUsersPageAsync(pageSize, endCursor).ConfigureAwait(false);
-            } catch (HttpRequestException) {
-                yield break;
-            }
+            (List<WizUser> Users, bool HasNextPage, string? EndCursor) result =
+                await GetUsersPageAsync(pageSize, endCursor).ConfigureAwait(false);
 
             foreach (var user in result.Users) {
                 if (cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
## Summary
- stop swallowing `HttpRequestException` in `GetUsersAsyncEnumerable`
- adjust test to ensure the exception isn't suppressed

## Testing
- `dotnet test WizCloud.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688be03f96a8832eb1ebcfef18593a3e