### PR TITLE
Implement parameter set exclusivity for Connect-Wiz

### DIFF
--- a/Module/Tests/ConnectWiz.Tests.ps1
+++ b/Module/Tests/ConnectWiz.Tests.ps1
@@ -4,4 +4,11 @@ Describe 'Connect-Wiz cmdlet' {
         $source = Get-Content -Path (Join-Path $repoRoot 'WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs') -Raw
         $source | Should -Match 'HttpRequestException'
     }
+
+    It 'defines exclusive parameter sets' {
+        $repoRoot = Resolve-Path -Path "$PSScriptRoot/../.."
+        $source = Get-Content -Path (Join-Path $repoRoot 'WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs') -Raw
+        $source | Should -Match 'ParameterSetName\s*=\s*TokenParameterSet'
+        $source | Should -Match 'ParameterSetName\s*=\s*ClientCredentialParameterSet'
+    }
 }


### PR DESCRIPTION
## Summary
- add `TokenParameterSet` and `ClientCredentialParameterSet` to `Connect-Wiz`
- update logic to acquire tokens based on parameter set
- persist client credentials only when provided
- extend Pester tests for new parameter sets

## Testing
- `dotnet build WizCloud.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command ./Module/WizCloud.Tests.ps1`
- `dotnet test WizCloud.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_688be0221c30832e837b39c4addacbca