### PR TITLE
Fix numbering in GetUsers example

### DIFF
--- a/Module/Examples/GetUsers.ps1
+++ b/Module/Examples/GetUsers.ps1
@@ -41,6 +41,6 @@ $null = Get-WizUser -Verbose
 # Example 9: Connect using client credentials
 $null = Connect-Wiz -ClientId $env:WIZ_CLIENT_ID -ClientSecret $env:WIZ_CLIENT_SECRET -TestConnection
 
-# Example 9: Stream users as they are retrieved
+# Example 10: Stream users as they are retrieved
 Get-WizUser | Select-Object Name, Type | Format-Table
 


### PR DESCRIPTION
## Summary
- correct the numbering for the final example in `GetUsers.ps1`

## Testing
- `pwsh -File Module/Examples/GetUsers.ps1`
- `dotnet test WizCloud.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_688be01b5644832ea520e7aed46f3ee7