### PR TITLE
Fix assembly import block comment

### DIFF
--- a/Module/WizCloud.psm1
+++ b/Module/WizCloud.psm1
@@ -103,7 +103,6 @@ $FoundErrors = @(
         try {
             Write-Verbose -Message $Import.FullName
             Add-Type -Path $Import.Fullname -ErrorAction Stop
-            #  }
         } catch [System.Reflection.ReflectionTypeLoadException] {
             Write-Warning "Processing $($Import.Name) Exception: $($_.Exception.Message)"
             $LoaderExceptions = $($_.Exception.LoaderExceptions) | Sort-Object -Unique


### PR DESCRIPTION
## Summary
- clean up stray `#  }` comment in WizCloud.psm1

## Testing
- `dotnet build WizCloud.sln -c Release`
- `dotnet build WizCloud.sln`
- `dotnet test WizCloud.sln --no-build -c Release`
- `pwsh -NoLogo -NoProfile -Command "Import-Module ./Module/WizCloud.psd1 -Force; 'MODULE_LOADED'"`
- `Invoke-Pester -Path Module/Tests -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_688be013f258832ea1200b0d8df46886