### PR TITLE
Add filtering for Get-WizUser and WizClient

### DIFF
--- a/Module/Examples/GetUsers.ps1
+++ b/Module/Examples/GetUsers.ps1
@@ -44,3 +44,7 @@ $null = Connect-Wiz -ClientId $env:WIZ_CLIENT_ID -ClientSecret $env:WIZ_CLIENT_S
 # Example 9: Stream users as they are retrieved
 Get-WizUser | Select-Object Name, Type | Format-Table
 
+# Example 10: Get only service accounts from a specific project
+$serviceAccounts = Get-WizUser -Type SERVICE_ACCOUNT -ProjectId "project1"
+Write-Host "Found $($serviceAccounts.Count) service accounts in project1"
+

--- a/Module/Tests/GetWizUser.Tests.ps1
+++ b/Module/Tests/GetWizUser.Tests.ps1
@@ -10,4 +10,11 @@ Describe 'Get-WizUser cmdlet' {
         $source = Get-Content -Path (Join-Path $repoRoot 'WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs') -Raw
         $source | Should -Match 'HttpRequestException'
     }
+
+    It 'defines Type and ProjectId parameters' {
+        $repoRoot = Resolve-Path -Path "$PSScriptRoot/../.."
+        $source = Get-Content -Path (Join-Path $repoRoot 'WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs') -Raw
+        $source | Should -Match 'ProjectId'
+        $source | Should -Match 'WizUserType\[]'
+    }
 }

--- a/WizCloud.Examples/Program.cs
+++ b/WizCloud.Examples/Program.cs
@@ -9,5 +9,6 @@ internal class Program {
         await ErrorHandlingSample.RunAsync();
         await GraphQlQueriesSample.RunAsync();
         await CloudAccountsSample.RunAsync();
+        await FilterUsersSample.RunAsync();
     }
 }

--- a/WizCloud.Examples/Samples/FilterUsersSample.cs
+++ b/WizCloud.Examples/Samples/FilterUsersSample.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading.Tasks;
+
+namespace WizCloud.Examples;
+internal static class FilterUsersSample {
+    public static async Task RunAsync() {
+        var token = await WizAuthentication.AcquireTokenAsync("clientId", "clientSecret");
+        using var client = new WizClient(token);
+        var users = await client.GetUsersAsync(types: new[] { WizUserType.SERVICE_ACCOUNT }, projectId: "project1");
+        Console.WriteLine($"Filter sample retrieved {users.Count} user(s).");
+        if (users.Count > 0) {
+            Console.WriteLine($"First filtered user: {users[0].Name}");
+        }
+    }
+}

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
@@ -45,6 +45,12 @@ public class CmdletGetWizUser : AsyncPSCmdlet {
     [ValidateRange(1, 500)]
     public int PageSize { get; set; } = 20;
 
+    [Parameter(Mandatory = false, HelpMessage = "Filter by Wiz user types.")]
+    public WizUserType[] Type { get; set; } = Array.Empty<WizUserType>();
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    public string? ProjectId { get; set; }
+
 
     private WizClient? _wizClient;
 
@@ -116,7 +122,7 @@ public class CmdletGetWizUser : AsyncPSCmdlet {
             var progressRecord = new ProgressRecord(1, "Get-WizUser", "Retrieving users from Wiz...");
             WriteProgress(progressRecord);
 
-            await foreach (var user in _wizClient.GetUsersAsyncEnumerable(PageSize, CancelToken)) {
+            await foreach (var user in _wizClient.GetUsersAsyncEnumerable(PageSize, Type, ProjectId, CancelToken)) {
                 if (CancelToken.IsCancellationRequested)
                     break;
 

--- a/WizCloud.Tests/GetUsersPageAsyncTests.cs
+++ b/WizCloud.Tests/GetUsersPageAsyncTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetUsersPageAsyncTests {
+    [TestMethod]
+    public void Method_HasFilterParameters() {
+        const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+        var method = typeof(WizClient).GetMethod("GetUsersPageAsync", flags);
+        Assert.IsNotNull(method);
+        var parameters = method!.GetParameters();
+        Assert.IsTrue(parameters.Length >= 4);
+        Assert.AreEqual("types", parameters[2].Name);
+        Assert.AreEqual("projectId", parameters[3].Name);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `WizClient.GetUsersPageAsync` with filter arguments
- pass filter parameters through `GetUsersAsync` and `GetUsersAsyncEnumerable`
- update `Get-WizUser` cmdlet to expose `Type` and `ProjectId`
- demonstrate filtering in examples
- add corresponding MSTest and Pester tests

## Testing
- `dotnet test WizCloud.sln -c Release`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester Module/Tests"`

------
https://chatgpt.com/codex/tasks/task_e_688be052e514832e98c022e2e1fa9b96