### PR TITLE
Implement Get-WizIssue cmdlet and client functionality

### DIFF
--- a/Module/Examples/GetIssues.ps1
+++ b/Module/Examples/GetIssues.ps1
@@ -1,0 +1,17 @@
+# Import the WizCloud module
+Import-Module $PSScriptRoot\..\WizCloud.psd1 -Force
+
+# Connect to Wiz
+$connectWizSplat = @{
+    ClientId       = $Env:WizClientID
+    ClientSecret   = $Env:WizClientSecret
+    TestConnection = $true
+    Region         = 'eu17'
+}
+Connect-Wiz @connectWizSplat
+
+# Get issues
+Write-Host "`nRetrieving issues..." -ForegroundColor Yellow
+$issues = Get-WizIssue -Verbose -MaxResults 50
+Write-Host "`nFound $($issues.Count) issues" -ForegroundColor Green
+$issues | Format-Table Id, Name, Severity, Status

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizIssue.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizIssue.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Management.Automation;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WizCloud;
+
+namespace WizCloud.PowerShell;
+
+/// <summary>
+/// <para type="synopsis">Gets security issues from Wiz.io.</para>
+/// <para type="description">The Get-WizIssue cmdlet retrieves security issues from Wiz.io using streaming enumeration.</para>
+/// <example>
+/// <para>Get all issues from Wiz:</para>
+/// <code>Get-WizIssue</code>
+/// </example>
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "WizIssue")]
+[OutputType(typeof(WizIssue))]
+public class CmdletGetWizIssue : AsyncPSCmdlet {
+    /// <summary>
+    /// <para type="description">The number of issues to retrieve per page. Default is 20.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, HelpMessage = "The number of issues to retrieve per page.")]
+    [ValidateRange(1, 5000)]
+    public int PageSize { get; set; } = 500;
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by issue severities.")]
+    public WizSeverity[] Severity { get; set; } = Array.Empty<WizSeverity>();
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by issue status.")]
+    public string[] Status { get; set; } = Array.Empty<string>();
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    public string? ProjectId { get; set; }
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by issue types.")]
+    public string[] Type { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// <para type="description">The maximum number of issues to retrieve. Default is unlimited.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, HelpMessage = "Maximum number of issues to retrieve. Default is unlimited.")]
+    [ValidateRange(1, int.MaxValue)]
+    public int? MaxResults { get; set; }
+
+    private WizClient? _wizClient;
+    private int _retrievedCount = 0;
+
+    /// <summary>
+    /// Initialize the Wiz client.
+    /// </summary>
+    protected override Task BeginProcessingAsync() {
+        try {
+            var token = ModuleInitialization.DefaultToken;
+            if (string.IsNullOrEmpty(token)) {
+                WriteError(new ErrorRecord(
+                    new InvalidOperationException("No authentication found. Please use Connect-Wiz first."),
+                    "NoTokenAvailable",
+                    ErrorCategory.AuthenticationError,
+                    null));
+                return Task.CompletedTask;
+            }
+
+            WriteVerbose("Using stored token from Connect-Wiz");
+            var region = ModuleInitialization.DefaultRegion;
+            WriteVerbose($"Using region from Connect-Wiz: {region}");
+
+            var clientId = ModuleInitialization.DefaultClientId;
+            var clientSecret = ModuleInitialization.DefaultClientSecret;
+
+            _wizClient = !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret)
+                ? new WizClient(token, region, clientId, clientSecret)
+                : new WizClient(token, region);
+            WriteVerbose($"Connected to Wiz region: {region}");
+        } catch (HttpRequestException ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizApiHttpError",
+                ErrorCategory.ConnectionError,
+                null));
+        } catch (Exception ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizClientInitializationError",
+                ErrorCategory.ConnectionError,
+                null));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Retrieve and output Wiz issues.
+    /// </summary>
+    protected override async Task ProcessRecordAsync() {
+        if (_wizClient == null) {
+            WriteError(new ErrorRecord(
+                new InvalidOperationException("Wiz client is not initialized"),
+                "WizClientNotInitialized",
+                ErrorCategory.InvalidOperation,
+                null));
+            return;
+        }
+
+        try {
+            WriteVerbose($"Retrieving Wiz issues with page size: {PageSize}" +
+                (MaxResults.HasValue ? $", max results: {MaxResults.Value}" : ""));
+
+            var progressRecord = new ProgressRecord(1, "Get-WizIssue", "Retrieving issues from Wiz...");
+            WriteProgress(progressRecord);
+
+            await foreach (var issue in _wizClient.GetIssuesAsyncEnumerable(PageSize, Severity, Status, ProjectId, Type, CancelToken)) {
+                if (CancelToken.IsCancellationRequested)
+                    break;
+
+                WriteObject(issue);
+                _retrievedCount++;
+
+                if (MaxResults.HasValue) {
+                    var percentComplete = (int)((double)_retrievedCount / MaxResults.Value * 100);
+                    progressRecord.StatusDescription = $"Retrieved {_retrievedCount} of {MaxResults.Value} issues...";
+                    progressRecord.PercentComplete = percentComplete;
+                    WriteProgress(progressRecord);
+                } else if (_retrievedCount % 100 == 0) {
+                    progressRecord.StatusDescription = $"Retrieved {_retrievedCount} issues...";
+                    WriteProgress(progressRecord);
+                }
+
+                if (MaxResults.HasValue && _retrievedCount >= MaxResults.Value) {
+                    WriteVerbose($"Reached maximum result limit of {MaxResults.Value} issues");
+                    break;
+                }
+            }
+
+            progressRecord.StatusDescription = "Completed";
+            progressRecord.PercentComplete = 100;
+            progressRecord.RecordType = ProgressRecordType.Completed;
+            WriteProgress(progressRecord);
+        } catch (HttpRequestException ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizApiHttpError",
+                ErrorCategory.ReadError,
+                null));
+        } catch (Exception ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizIssueRetrievalError",
+                ErrorCategory.ReadError,
+                null));
+        }
+    }
+
+    /// <summary>
+    /// Clean up resources.
+    /// </summary>
+    protected override Task EndProcessingAsync() {
+        _wizClient?.Dispose();
+        return Task.CompletedTask;
+    }
+}

--- a/WizCloud.Tests/GetIssuesAsyncEnumerableTests.cs
+++ b/WizCloud.Tests/GetIssuesAsyncEnumerableTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetIssuesAsyncEnumerableTests {
+    [TestMethod]
+    public void MethodExistsWithCorrectReturnType() {
+        var method = typeof(WizClient).GetMethod("GetIssuesAsyncEnumerable");
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(IAsyncEnumerable<WizIssue>), method!.ReturnType);
+    }
+
+    [TestMethod]
+    public void MethodContainsErrorHandling() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
+        var source = File.ReadAllText(filePath);
+        var index = source.IndexOf("GetIssuesAsyncEnumerable", StringComparison.Ordinal);
+        Assert.IsTrue(index >= 0, "GetIssuesAsyncEnumerable method not found");
+        var snippet = source.Substring(index, Math.Min(800, source.Length - index));
+        StringAssert.Contains(snippet, "catch (HttpRequestException)");
+        StringAssert.Contains(snippet, "yield break");
+    }
+}

--- a/WizCloud.Tests/GetIssuesAsyncTests.cs
+++ b/WizCloud.Tests/GetIssuesAsyncTests.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetIssuesAsyncTests {
+    [TestMethod]
+    public void MethodExistsWithCorrectReturnType() {
+        var method = typeof(WizClient).GetMethod("GetIssuesAsync");
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(Task<List<WizIssue>>), method!.ReturnType);
+    }
+}

--- a/WizCloud.Tests/GetWizIssueTests.cs
+++ b/WizCloud.Tests/GetWizIssueTests.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetWizIssueTests {
+    [TestMethod]
+    public void ProgressRecordSetToCompleted() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud.PowerShell", "Cmdlets", "CmdletGetWizIssue.cs");
+        var source = File.ReadAllText(filePath);
+        StringAssert.Contains(source, "RecordType = ProgressRecordType.Completed");
+    }
+}

--- a/WizCloud.Tests/GraphQlQueriesTests.cs
+++ b/WizCloud.Tests/GraphQlQueriesTests.cs
@@ -28,4 +28,12 @@ public sealed class GraphQlQueriesTests {
         Assert.IsNotNull(field);
         Assert.AreEqual(typeof(string), field!.FieldType);
     }
+
+    [TestMethod]
+    public void IssuesQuery_ConstantExists() {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Static;
+        var field = typeof(GraphQlQueries).GetField("IssuesQuery", flags);
+        Assert.IsNotNull(field);
+        Assert.AreEqual(typeof(string), field!.FieldType);
+    }
 }

--- a/WizCloud.Tests/TokenRefreshTests.cs
+++ b/WizCloud.Tests/TokenRefreshTests.cs
@@ -52,4 +52,17 @@ public sealed class TokenRefreshTests {
         var paramIndex = source.IndexOf("clientId, clientSecret", ctorIndex, StringComparison.Ordinal);
         Assert.IsTrue(paramIndex >= 0, "Client credentials not supplied to WizClient constructor");
     }
+
+    [TestMethod]
+    public void GetWizIssueCmdlet_PassesClientCredentials() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud.PowerShell", "Cmdlets", "CmdletGetWizIssue.cs");
+        var source = File.ReadAllText(filePath);
+        StringAssert.Contains(source, "ModuleInitialization.DefaultClientId");
+        StringAssert.Contains(source, "ModuleInitialization.DefaultClientSecret");
+        var ctorIndex = source.IndexOf("new WizClient", StringComparison.Ordinal);
+        Assert.IsTrue(ctorIndex >= 0, "WizClient constructor call not found");
+        var paramIndex = source.IndexOf("clientId, clientSecret", ctorIndex, StringComparison.Ordinal);
+        Assert.IsTrue(paramIndex >= 0, "Client credentials not supplied to WizClient constructor");
+    }
 }

--- a/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
+++ b/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
@@ -14,5 +14,6 @@ public sealed class WizClientGraphQlQueriesTests {
         StringAssert.Contains(source, "GraphQlQueries.UsersQuery");
         StringAssert.Contains(source, "GraphQlQueries.ProjectsQuery");
         StringAssert.Contains(source, "GraphQlQueries.CloudAccountsQuery");
+        StringAssert.Contains(source, "GraphQlQueries.IssuesQuery");
     }
 }

--- a/WizCloud/GraphQlQueries.cs
+++ b/WizCloud/GraphQlQueries.cs
@@ -44,4 +44,41 @@ public static class GraphQlQueries {
                 nodes { id name cloudProvider externalId }
             }
         }";
+
+    /// <summary>
+    /// Query for retrieving security issues.
+    /// </summary>
+    public const string IssuesQuery = @"query Issues($first: Int, $after: String, $filterBy: IssueFilters) {
+            issues(first: $first, after: $after, filterBy: $filterBy) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                    id
+                    name
+                    type
+                    severity
+                    status
+                    createdAt
+                    updatedAt
+                    resolvedAt
+                    dueAt
+                    projects { id name }
+                    resource {
+                        id
+                        name
+                        type
+                        cloudPlatform
+                        region
+                        subscriptionId
+                    }
+                    control {
+                        id
+                        name
+                        description
+                        severity
+                    }
+                    evidence
+                    remediation
+                }
+            }
+        }";
 }

--- a/WizCloud/Models/WizIssue.cs
+++ b/WizCloud/Models/WizIssue.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace WizCloud;
+
+/// <summary>
+/// Represents a security issue returned by the Wiz API.
+/// </summary>
+public class WizIssue {
+    /// <summary>
+    /// Gets or sets the unique identifier of the issue.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the issue.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the type of the issue.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the severity of the issue.
+    /// </summary>
+    public WizSeverity? Severity { get; set; }
+
+    /// <summary>
+    /// Gets or sets the status of the issue.
+    /// </summary>
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// Gets or sets the creation timestamp.
+    /// </summary>
+    public DateTime? CreatedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last update timestamp.
+    /// </summary>
+    public DateTime? UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resolution timestamp.
+    /// </summary>
+    public DateTime? ResolvedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the due date for the issue.
+    /// </summary>
+    public DateTime? DueAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the projects associated with this issue.
+    /// </summary>
+    public List<WizProject> Projects { get; set; } = new List<WizProject>();
+
+    /// <summary>
+    /// Gets or sets the affected resource.
+    /// </summary>
+    public WizIssueResource? Resource { get; set; }
+
+    /// <summary>
+    /// Gets or sets the control that triggered the issue.
+    /// </summary>
+    public WizIssueControl? Control { get; set; }
+
+    /// <summary>
+    /// Gets or sets evidence associated with the issue.
+    /// </summary>
+    public string? Evidence { get; set; }
+
+    /// <summary>
+    /// Gets or sets remediation guidance for the issue.
+    /// </summary>
+    public string? Remediation { get; set; }
+
+    /// <summary>
+    /// Creates a <see cref="WizIssue"/> from JSON.
+    /// </summary>
+    public static WizIssue FromJson(JsonNode node) {
+        var issue = new WizIssue {
+            Id = node["id"]?.GetValue<string>() ?? string.Empty,
+            Name = node["name"]?.GetValue<string>() ?? string.Empty,
+            Type = node["type"]?.GetValue<string>() ?? string.Empty,
+            Severity = Enum.TryParse(node["severity"]?.GetValue<string>(), true, out WizSeverity tmpSev) ? tmpSev : null,
+            Status = node["status"]?.GetValue<string>(),
+            CreatedAt = node["createdAt"]?.GetValue<DateTime?>()?.ToLocalTime(),
+            UpdatedAt = node["updatedAt"]?.GetValue<DateTime?>()?.ToLocalTime(),
+            ResolvedAt = node["resolvedAt"]?.GetValue<DateTime?>()?.ToLocalTime(),
+            DueAt = node["dueAt"]?.GetValue<DateTime?>()?.ToLocalTime()
+        };
+
+        var projects = node["projects"]?.AsArray();
+        if (projects != null) {
+            foreach (var proj in projects) {
+                if (proj is JsonObject obj) {
+                    issue.Projects.Add(new WizProject {
+                        Id = obj["id"]?.GetValue<string>() ?? string.Empty,
+                        Name = obj["name"]?.GetValue<string>() ?? string.Empty,
+                        Slug = string.Empty,
+                        IsFolder = false
+                    });
+                }
+            }
+        }
+
+        var resource = node["resource"];
+        if (resource != null) {
+            issue.Resource = WizIssueResource.FromJson(resource);
+        }
+
+        var control = node["control"];
+        if (control != null) {
+            issue.Control = WizIssueControl.FromJson(control);
+        }
+
+        issue.Evidence = node["evidence"]?.GetValue<string>();
+        issue.Remediation = node["remediation"]?.GetValue<string>();
+
+        return issue;
+    }
+}

--- a/WizCloud/Models/WizIssueControl.cs
+++ b/WizCloud/Models/WizIssueControl.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace WizCloud;
+
+/// <summary>
+/// Represents the security control that generated an issue.
+/// </summary>
+public class WizIssueControl {
+    /// <summary>
+    /// Gets or sets the unique identifier of the control.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the control.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the description of the control.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the severity of the control.
+    /// </summary>
+    public WizSeverity? Severity { get; set; }
+
+    /// <summary>
+    /// Creates a <see cref="WizIssueControl"/> from JSON.
+    /// </summary>
+    public static WizIssueControl FromJson(JsonNode node) {
+        return new WizIssueControl {
+            Id = node["id"]?.GetValue<string>() ?? string.Empty,
+            Name = node["name"]?.GetValue<string>() ?? string.Empty,
+            Description = node["description"]?.GetValue<string>(),
+            Severity = Enum.TryParse(node["severity"]?.GetValue<string>(), true, out WizSeverity tmpSev) ? tmpSev : null
+        };
+    }
+}

--- a/WizCloud/Models/WizIssueResource.cs
+++ b/WizCloud/Models/WizIssueResource.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace WizCloud;
+
+/// <summary>
+/// Represents the resource associated with a security issue.
+/// </summary>
+public class WizIssueResource {
+    /// <summary>
+    /// Gets or sets the unique identifier of the resource.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the resource.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the type of the resource.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the cloud platform hosting the resource.
+    /// </summary>
+    public WizCloudProvider? CloudPlatform { get; set; }
+
+    /// <summary>
+    /// Gets or sets the region of the resource.
+    /// </summary>
+    public string? Region { get; set; }
+
+    /// <summary>
+    /// Gets or sets the subscription identifier for the resource.
+    /// </summary>
+    public string? SubscriptionId { get; set; }
+
+    /// <summary>
+    /// Creates a <see cref="WizIssueResource"/> from JSON.
+    /// </summary>
+    public static WizIssueResource FromJson(JsonNode node) {
+        return new WizIssueResource {
+            Id = node["id"]?.GetValue<string>() ?? string.Empty,
+            Name = node["name"]?.GetValue<string>() ?? string.Empty,
+            Type = node["type"]?.GetValue<string>() ?? string.Empty,
+            CloudPlatform = Enum.TryParse(node["cloudPlatform"]?.GetValue<string>(), true, out WizCloudProvider tmpCp) ? tmpCp : null,
+            Region = node["region"]?.GetValue<string>(),
+            SubscriptionId = node["subscriptionId"]?.GetValue<string>()
+        };
+    }
+}

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -429,6 +429,140 @@ public class WizClient : IDisposable {
     }
 
     /// <summary>
+    /// Retrieves all issues from Wiz asynchronously.
+    /// </summary>
+    public async Task<List<WizIssue>> GetIssuesAsync(
+        int pageSize = 20,
+        IEnumerable<WizSeverity>? severities = null,
+        IEnumerable<string>? statuses = null,
+        string? projectId = null,
+        IEnumerable<string>? types = null) {
+        var issues = new List<WizIssue>();
+        string? endCursor = null;
+        bool hasNextPage = true;
+
+        while (hasNextPage) {
+            var result = await GetIssuesPageAsync(pageSize, endCursor, severities, statuses, projectId, types).ConfigureAwait(false);
+            issues.AddRange(result.Issues);
+            hasNextPage = result.HasNextPage;
+            endCursor = result.EndCursor;
+        }
+
+        return issues;
+    }
+
+    /// <summary>
+    /// Streams issues from Wiz asynchronously.
+    /// </summary>
+    public async IAsyncEnumerable<WizIssue> GetIssuesAsyncEnumerable(
+        int pageSize = 20,
+        IEnumerable<WizSeverity>? severities = null,
+        IEnumerable<string>? statuses = null,
+        string? projectId = null,
+        IEnumerable<string>? types = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        string? endCursor = null;
+        bool hasNextPage = true;
+
+        while (!cancellationToken.IsCancellationRequested && hasNextPage) {
+            (List<WizIssue> Issues, bool HasNextPage, string? EndCursor) result;
+            try {
+                result = await GetIssuesPageAsync(pageSize, endCursor, severities, statuses, projectId, types).ConfigureAwait(false);
+            } catch (HttpRequestException) {
+                yield break;
+            }
+
+            foreach (var issue in result.Issues) {
+                if (cancellationToken.IsCancellationRequested)
+                    yield break;
+
+                yield return issue;
+            }
+
+            hasNextPage = result.HasNextPage;
+            endCursor = result.EndCursor;
+        }
+    }
+
+    /// <summary>
+    /// Retrieves a single page of issues from the Wiz API.
+    /// </summary>
+    private async Task<(List<WizIssue> Issues, bool HasNextPage, string? EndCursor)> GetIssuesPageAsync(
+        int first,
+        string? after = null,
+        IEnumerable<WizSeverity>? severities = null,
+        IEnumerable<string>? statuses = null,
+        string? projectId = null,
+        IEnumerable<string>? types = null) {
+        const string query = GraphQlQueries.IssuesQuery;
+
+        var severityFilter = severities != null && severities.Any()
+            ? new { equals = severities.Select(s => s.ToString()) }
+            : null;
+        var statusFilter = statuses != null && statuses.Any()
+            ? new { equals = statuses }
+            : null;
+        var typeFilter = types != null && types.Any()
+            ? new { equals = types }
+            : null;
+        var projectFilter = projectId != null ? new { equals = new[] { projectId } } : null;
+
+        var variables = new {
+            first,
+            after,
+            filterBy = new {
+                severity = severityFilter,
+                status = statusFilter,
+                type = typeFilter,
+                projectId = projectFilter
+            }
+        };
+
+        var requestBody = new { query, variables };
+
+        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            request.Content = new StringContent(
+                JsonSerializer.Serialize(requestBody),
+                Encoding.UTF8,
+                "application/json"
+            );
+
+            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
+                if (!response.IsSuccessStatusCode) {
+                    var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var message = $"Request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase}).";
+                    if (!string.IsNullOrWhiteSpace(errorBody))
+                        message += $" Body: {errorBody}";
+                    throw new HttpRequestException(message);
+                }
+
+                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var jsonResponse = JsonNode.Parse(content);
+
+                if (jsonResponse == null)
+                    throw new InvalidOperationException("Received null response from API");
+
+                var issues = new List<WizIssue>();
+                var nodes = jsonResponse["data"]?["issues"]?["nodes"]?.AsArray();
+
+                if (nodes != null) {
+                    foreach (var node in nodes) {
+                        if (node != null)
+                            issues.Add(WizIssue.FromJson(node));
+                    }
+                }
+
+                var pageInfo = jsonResponse["data"]?["issues"]?["pageInfo"];
+                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+                return (issues, hasNextPage, endCursor);
+            }
+        }
+    }
+
+    /// <summary>
     /// Releases all resources used by the WizClient.
     /// </summary>
     public void Dispose() {


### PR DESCRIPTION
## Summary
- add IssuesQuery in GraphQlQueries
- add WizIssue models for issues, resources and controls
- implement issue retrieval methods in `WizClient`
- add `Get-WizIssue` cmdlet with paging and filtering
- provide PowerShell example script for getting issues
- add MSTest coverage for new methods and cmdlet

## Testing
- `dotnet build WizCloud.sln -c Release`
- `dotnet test WizCloud.Tests/WizCloud.Tests.csproj -c Release --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688cb8c3b270832e9ac0c5cedc93971b