### PR TITLE
Add WizResource querying support

### DIFF
--- a/Module/Examples/GetResources.ps1
+++ b/Module/Examples/GetResources.ps1
@@ -1,0 +1,17 @@
+# Import the WizCloud module
+Import-Module $PSScriptRoot\..\WizCloud.psd1 -Force
+
+# Connect to Wiz
+$connectWizSplat = @{
+    ClientId       = $Env:WizClientID
+    ClientSecret   = $Env:WizClientSecret
+    TestConnection = $true
+    Region         = 'eu17'
+}
+Connect-Wiz @connectWizSplat
+
+# Get resources
+Write-Host "`nRetrieving resources..." -ForegroundColor Yellow
+$resources = Get-WizResource -Verbose -MaxResults 50 -Type VM -CloudProvider AWS
+Write-Host "`nFound $($resources.Count) resources" -ForegroundColor Green
+$resources | Format-Table Id, Name, Type, CloudPlatform, Region

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizResource.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizResource.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WizCloud;
+
+namespace WizCloud.PowerShell;
+/// <summary>
+/// <para type="synopsis">Gets cloud resources from Wiz.io.</para>
+/// <para type="description">The Get-WizResource cmdlet retrieves resources from Wiz.io inventory.</para>
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "WizResource")]
+[OutputType(typeof(WizResource))]
+public class CmdletGetWizResource : AsyncPSCmdlet {
+    /// <summary>
+    /// <para type="description">The number of resources to retrieve per page. Default is 500.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, HelpMessage = "The number of resources to retrieve per page.")]
+    [ValidateRange(1, 5000)]
+    public int PageSize { get; set; } = 500;
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by resource type.")]
+    public string[] Type { get; set; } = Array.Empty<string>();
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by cloud provider.")]
+    public WizCloudProvider[] CloudProvider { get; set; } = Array.Empty<WizCloudProvider>();
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by resource region.")]
+    public string? Region { get; set; }
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by public accessibility.")]
+    public SwitchParameter PubliclyAccessible { get; set; }
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by tags.")]
+    public Hashtable? Tag { get; set; }
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    public string? ProjectId { get; set; }
+
+    [Parameter(Mandatory = false, HelpMessage = "Maximum number of resources to retrieve. Default is unlimited.")]
+    [ValidateRange(1, int.MaxValue)]
+    public int? MaxResults { get; set; }
+
+    private WizClient? _wizClient;
+    private int _retrievedCount = 0;
+
+    /// <summary>
+    /// Initialize the Wiz client.
+    /// </summary>
+    protected override Task BeginProcessingAsync() {
+        try {
+            var token = ModuleInitialization.DefaultToken;
+            if (string.IsNullOrEmpty(token)) {
+                WriteError(new ErrorRecord(
+                    new InvalidOperationException("No authentication found. Please use Connect-Wiz first."),
+                    "NoTokenAvailable",
+                    ErrorCategory.AuthenticationError,
+                    null));
+                return Task.CompletedTask;
+            }
+            WriteVerbose("Using stored token from Connect-Wiz");
+            var region = ModuleInitialization.DefaultRegion;
+            WriteVerbose($"Using region from Connect-Wiz: {region}");
+
+            var clientId = ModuleInitialization.DefaultClientId;
+            var clientSecret = ModuleInitialization.DefaultClientSecret;
+
+            _wizClient = !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret)
+                ? new WizClient(token, region, clientId, clientSecret)
+                : new WizClient(token, region);
+            WriteVerbose($"Connected to Wiz region: {region}");
+        } catch (HttpRequestException ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizApiHttpError",
+                ErrorCategory.ConnectionError,
+                null));
+        } catch (Exception ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizClientInitializationError",
+                ErrorCategory.ConnectionError,
+                null));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Retrieve and output Wiz resources.
+    /// </summary>
+    protected override async Task ProcessRecordAsync() {
+        if (_wizClient == null) {
+            WriteError(new ErrorRecord(
+                new InvalidOperationException("Wiz client is not initialized"),
+                "WizClientNotInitialized",
+                ErrorCategory.InvalidOperation,
+                null));
+            return;
+        }
+
+        try {
+            WriteVerbose($"Retrieving Wiz resources with page size: {PageSize}" +
+                (MaxResults.HasValue ? $", max results: {MaxResults.Value}" : ""));
+
+            var progressRecord = new ProgressRecord(1, "Get-WizResource", "Retrieving resources from Wiz...");
+            WriteProgress(progressRecord);
+
+            IDictionary<string, string>? tagDict = null;
+            if (Tag != null && Tag.Count > 0) {
+                tagDict = new Dictionary<string, string>();
+                foreach (DictionaryEntry entry in Tag) {
+                    tagDict[entry.Key.ToString()!] = entry.Value?.ToString() ?? string.Empty;
+                }
+            }
+
+            await foreach (var resource in _wizClient.GetResourcesAsyncEnumerable(
+                PageSize,
+                Type,
+                CloudProvider,
+                Region,
+                PubliclyAccessible.IsPresent ? true : (bool?)null,
+                tagDict,
+                ProjectId,
+                CancelToken)) {
+                if (CancelToken.IsCancellationRequested)
+                    break;
+
+                WriteObject(resource);
+                _retrievedCount++;
+
+                if (MaxResults.HasValue) {
+                    var percentComplete = (int)((double)_retrievedCount / MaxResults.Value * 100);
+                    progressRecord.StatusDescription = $"Retrieved {_retrievedCount} of {MaxResults.Value} resources...";
+                    progressRecord.PercentComplete = percentComplete;
+                    WriteProgress(progressRecord);
+                } else if (_retrievedCount % 100 == 0) {
+                    progressRecord.StatusDescription = $"Retrieved {_retrievedCount} resources...";
+                    WriteProgress(progressRecord);
+                }
+
+                if (MaxResults.HasValue && _retrievedCount >= MaxResults.Value) {
+                    WriteVerbose($"Reached maximum result limit of {MaxResults.Value} resources");
+                    break;
+                }
+            }
+
+            progressRecord.StatusDescription = "Completed";
+            progressRecord.PercentComplete = 100;
+            progressRecord.RecordType = ProgressRecordType.Completed;
+            WriteProgress(progressRecord);
+        } catch (HttpRequestException ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizApiHttpError",
+                ErrorCategory.ReadError,
+                null));
+        } catch (Exception ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizResourceRetrievalError",
+                ErrorCategory.ReadError,
+                null));
+        }
+    }
+
+    /// <summary>
+    /// Clean up resources.
+    /// </summary>
+    protected override Task EndProcessingAsync() {
+        _wizClient?.Dispose();
+        return Task.CompletedTask;
+    }
+}

--- a/WizCloud.Tests/GetResourcesAsyncEnumerableTests.cs
+++ b/WizCloud.Tests/GetResourcesAsyncEnumerableTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetResourcesAsyncEnumerableTests {
+    [TestMethod]
+    public void MethodExistsWithCorrectReturnType() {
+        var method = typeof(WizClient).GetMethod("GetResourcesAsyncEnumerable");
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(IAsyncEnumerable<WizResource>), method!.ReturnType);
+    }
+
+    [TestMethod]
+    public void MethodContainsErrorHandling() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
+        var source = File.ReadAllText(filePath);
+        var index = source.IndexOf("GetResourcesAsyncEnumerable", StringComparison.Ordinal);
+        Assert.IsTrue(index >= 0, "GetResourcesAsyncEnumerable method not found");
+        var snippet = source.Substring(index, Math.Min(1200, source.Length - index));
+        StringAssert.Contains(snippet, "catch (HttpRequestException)");
+        StringAssert.Contains(snippet, "yield break");
+    }
+}

--- a/WizCloud.Tests/GetResourcesAsyncTests.cs
+++ b/WizCloud.Tests/GetResourcesAsyncTests.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetResourcesAsyncTests {
+    [TestMethod]
+    public void MethodExistsWithCorrectReturnType() {
+        var method = typeof(WizClient).GetMethod("GetResourcesAsync");
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(Task<List<WizResource>>), method!.ReturnType);
+    }
+}

--- a/WizCloud.Tests/GetWizResourceTests.cs
+++ b/WizCloud.Tests/GetWizResourceTests.cs
@@ -1,0 +1,16 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetWizResourceTests {
+    [TestMethod]
+    public void ProgressRecordSetToCompleted() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud.PowerShell", "Cmdlets", "CmdletGetWizResource.cs");
+        var source = File.ReadAllText(filePath);
+        StringAssert.Contains(source, "RecordType = ProgressRecordType.Completed");
+    }
+}

--- a/WizCloud.Tests/GraphQlQueriesTests.cs
+++ b/WizCloud.Tests/GraphQlQueriesTests.cs
@@ -36,4 +36,12 @@ public sealed class GraphQlQueriesTests {
         Assert.IsNotNull(field);
         Assert.AreEqual(typeof(string), field!.FieldType);
     }
+
+    [TestMethod]
+    public void ResourcesQuery_ConstantExists() {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Static;
+        var field = typeof(GraphQlQueries).GetField("ResourcesQuery", flags);
+        Assert.IsNotNull(field);
+        Assert.AreEqual(typeof(string), field!.FieldType);
+    }
 }

--- a/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
+++ b/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
@@ -15,5 +15,6 @@ public sealed class WizClientGraphQlQueriesTests {
         StringAssert.Contains(source, "GraphQlQueries.ProjectsQuery");
         StringAssert.Contains(source, "GraphQlQueries.CloudAccountsQuery");
         StringAssert.Contains(source, "GraphQlQueries.IssuesQuery");
+        StringAssert.Contains(source, "GraphQlQueries.ResourcesQuery");
     }
 }

--- a/WizCloud/GraphQlQueries.cs
+++ b/WizCloud/GraphQlQueries.cs
@@ -81,4 +81,35 @@ public static class GraphQlQueries {
                 }
             }
         }";
+
+    /// <summary>
+    /// Query for retrieving cloud resources.
+    /// </summary>
+    public const string ResourcesQuery = @"query Resources($first: Int, $after: String, $filterBy: ResourceFilters) {
+            resources(first: $first, after: $after, filterBy: $filterBy) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                    id
+                    name
+                    type
+                    nativeType
+                    cloudPlatform
+                    cloudAccount { id name }
+                    region
+                    tags
+                    createdAt
+                    status
+                    publiclyAccessible
+                    hasPublicIpAddress
+                    isInternetFacing
+                    securityGroups
+                    issues {
+                        criticalCount
+                        highCount
+                        mediumCount
+                        lowCount
+                    }
+                }
+            }
+        }";
 }

--- a/WizCloud/Models/WizResource.cs
+++ b/WizCloud/Models/WizResource.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace WizCloud;
+/// <summary>
+/// Represents a generic cloud resource returned by the Wiz API.
+/// </summary>
+public class WizResource {
+    /// <summary>Gets or sets the unique identifier of the resource.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the name of the resource.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the general type of the resource.</summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the native provider type of the resource.</summary>
+    public string? NativeType { get; set; }
+
+    /// <summary>Gets or sets the cloud platform hosting the resource.</summary>
+    public WizCloudProvider? CloudPlatform { get; set; }
+
+    /// <summary>Gets or sets the owning cloud account.</summary>
+    public WizCloudAccount? CloudAccount { get; set; }
+
+    /// <summary>Gets or sets the region where the resource resides.</summary>
+    public string? Region { get; set; }
+
+    /// <summary>Gets or sets the resource tags.</summary>
+    public Dictionary<string, string> Tags { get; set; } = new();
+
+    /// <summary>Gets or sets the creation timestamp.</summary>
+    public DateTime? CreatedAt { get; set; }
+
+    /// <summary>Gets or sets the current status.</summary>
+    public string? Status { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the resource is publicly accessible.</summary>
+    public bool PubliclyAccessible { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the resource has a public IP address.</summary>
+    public bool HasPublicIpAddress { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the resource is internet facing.</summary>
+    public bool IsInternetFacing { get; set; }
+
+    /// <summary>Gets or sets the list of security groups associated with the resource.</summary>
+    public List<string> SecurityGroups { get; set; } = new();
+
+    /// <summary>Gets or sets issue counts for the resource.</summary>
+    public WizResourceIssueCounts? Issues { get; set; }
+
+    /// <summary>Creates a <see cref="WizResource"/> from JSON.</summary>
+    public static WizResource FromJson(JsonNode node) {
+        var resource = new WizResource {
+            Id = node["id"]?.GetValue<string>() ?? string.Empty,
+            Name = node["name"]?.GetValue<string>() ?? string.Empty,
+            Type = node["type"]?.GetValue<string>() ?? string.Empty,
+            NativeType = node["nativeType"]?.GetValue<string>(),
+            CloudPlatform = Enum.TryParse(node["cloudPlatform"]?.GetValue<string>(), true, out WizCloudProvider tmpCp) ? tmpCp : null,
+            Region = node["region"]?.GetValue<string>(),
+            CreatedAt = node["createdAt"]?.GetValue<DateTime?>()?.ToLocalTime(),
+            Status = node["status"]?.GetValue<string>(),
+            PubliclyAccessible = node["publiclyAccessible"]?.GetValue<bool>() ?? false,
+            HasPublicIpAddress = node["hasPublicIpAddress"]?.GetValue<bool>() ?? false,
+            IsInternetFacing = node["isInternetFacing"]?.GetValue<bool>() ?? false
+        };
+
+        var tags = node["tags"] as JsonObject;
+        if (tags != null) {
+            foreach (var tag in tags) {
+                resource.Tags[tag.Key] = tag.Value?.GetValue<string>() ?? string.Empty;
+            }
+        }
+
+        var cloudAccount = node["cloudAccount"];
+        if (cloudAccount != null) {
+            resource.CloudAccount = WizCloudAccount.FromJson(cloudAccount);
+        }
+
+        var secGroups = node["securityGroups"]?.AsArray();
+        if (secGroups != null) {
+            foreach (var sg in secGroups) {
+                if (sg != null) {
+                    resource.SecurityGroups.Add(sg.GetValue<string>());
+                }
+            }
+        }
+
+        var issues = node["issues"];
+        if (issues != null) {
+            resource.Issues = WizResourceIssueCounts.FromJson(issues);
+        }
+
+        return resource;
+    }
+}

--- a/WizCloud/Models/WizResourceIssueCounts.cs
+++ b/WizCloud/Models/WizResourceIssueCounts.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Nodes;
+
+namespace WizCloud;
+/// <summary>
+/// Represents issue summary counts for a resource.
+/// </summary>
+public class WizResourceIssueCounts {
+    /// <summary>Gets or sets the critical issue count.</summary>
+    public int CriticalCount { get; set; }
+    /// <summary>Gets or sets the high issue count.</summary>
+    public int HighCount { get; set; }
+    /// <summary>Gets or sets the medium issue count.</summary>
+    public int MediumCount { get; set; }
+    /// <summary>Gets or sets the low issue count.</summary>
+    public int LowCount { get; set; }
+
+    /// <summary>Creates a <see cref="WizResourceIssueCounts"/> from JSON.</summary>
+    public static WizResourceIssueCounts FromJson(JsonNode node) {
+        return new WizResourceIssueCounts {
+            CriticalCount = node["criticalCount"]?.GetValue<int>() ?? 0,
+            HighCount = node["highCount"]?.GetValue<int>() ?? 0,
+            MediumCount = node["mediumCount"]?.GetValue<int>() ?? 0,
+            LowCount = node["lowCount"]?.GetValue<int>() ?? 0
+        };
+    }
+}

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -563,6 +563,164 @@ public class WizClient : IDisposable {
     }
 
     /// <summary>
+    /// Retrieves all resources from Wiz asynchronously.
+    /// </summary>
+    public async Task<List<WizResource>> GetResourcesAsync(
+        int pageSize = 20,
+        IEnumerable<string>? types = null,
+        IEnumerable<WizCloudProvider>? cloudProviders = null,
+        string? region = null,
+        bool? publiclyAccessible = null,
+        IDictionary<string, string>? tags = null,
+        string? projectId = null) {
+        var resources = new List<WizResource>();
+        string? endCursor = null;
+        bool hasNextPage = true;
+
+        while (hasNextPage) {
+            var result = await GetResourcesPageAsync(
+                pageSize,
+                endCursor,
+                types,
+                cloudProviders,
+                region,
+                publiclyAccessible,
+                tags,
+                projectId).ConfigureAwait(false);
+            resources.AddRange(result.Resources);
+            hasNextPage = result.HasNextPage;
+            endCursor = result.EndCursor;
+        }
+
+        return resources;
+    }
+
+    /// <summary>
+    /// Streams resources from Wiz asynchronously.
+    /// </summary>
+    public async IAsyncEnumerable<WizResource> GetResourcesAsyncEnumerable(
+        int pageSize = 20,
+        IEnumerable<string>? types = null,
+        IEnumerable<WizCloudProvider>? cloudProviders = null,
+        string? region = null,
+        bool? publiclyAccessible = null,
+        IDictionary<string, string>? tags = null,
+        string? projectId = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        string? endCursor = null;
+        bool hasNextPage = true;
+
+        while (!cancellationToken.IsCancellationRequested && hasNextPage) {
+            (List<WizResource> Resources, bool HasNextPage, string? EndCursor) result;
+            try {
+                result = await GetResourcesPageAsync(
+                    pageSize,
+                    endCursor,
+                    types,
+                    cloudProviders,
+                    region,
+                    publiclyAccessible,
+                    tags,
+                    projectId).ConfigureAwait(false);
+            } catch (HttpRequestException) {
+                yield break;
+            }
+
+            foreach (var resource in result.Resources) {
+                if (cancellationToken.IsCancellationRequested)
+                    yield break;
+
+                yield return resource;
+            }
+
+            hasNextPage = result.HasNextPage;
+            endCursor = result.EndCursor;
+        }
+    }
+
+    /// <summary>
+    /// Retrieves a single page of resources from the Wiz API.
+    /// </summary>
+    private async Task<(List<WizResource> Resources, bool HasNextPage, string? EndCursor)> GetResourcesPageAsync(
+        int first,
+        string? after = null,
+        IEnumerable<string>? types = null,
+        IEnumerable<WizCloudProvider>? cloudProviders = null,
+        string? region = null,
+        bool? publiclyAccessible = null,
+        IDictionary<string, string>? tags = null,
+        string? projectId = null) {
+        const string query = GraphQlQueries.ResourcesQuery;
+
+        var typeFilter = types != null && types.Any() ? new { equals = types } : null;
+        var cloudProviderFilter = cloudProviders != null && cloudProviders.Any()
+            ? new { equals = cloudProviders.Select(cp => cp.ToString()) }
+            : null;
+        var regionFilter = region != null ? new { equals = new[] { region } } : null;
+        var publicFilter = publiclyAccessible.HasValue ? new { equals = publiclyAccessible.Value } : null;
+        var tagFilter = tags != null && tags.Count > 0
+            ? tags.Select(kvp => new { name = kvp.Key, equals = new[] { kvp.Value } }).ToArray()
+            : Array.Empty<object>();
+        var projectFilter = projectId != null ? new { equals = new[] { projectId } } : null;
+
+        var variables = new {
+            first,
+            after,
+            filterBy = new {
+                type = typeFilter,
+                cloudPlatform = cloudProviderFilter,
+                region = regionFilter,
+                publiclyAccessible = publicFilter,
+                tags = tagFilter,
+                projectId = projectFilter
+            }
+        };
+
+        var requestBody = new { query, variables };
+
+        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            request.Content = new StringContent(
+                JsonSerializer.Serialize(requestBody),
+                Encoding.UTF8,
+                "application/json"
+            );
+
+            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
+                if (!response.IsSuccessStatusCode) {
+                    var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var message = $"Request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase}).";
+                    if (!string.IsNullOrWhiteSpace(errorBody))
+                        message += $" Body: {errorBody}";
+                    throw new HttpRequestException(message);
+                }
+
+                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var jsonResponse = JsonNode.Parse(content);
+
+                if (jsonResponse == null)
+                    throw new InvalidOperationException("Received null response from API");
+
+                var resources = new List<WizResource>();
+                var nodes = jsonResponse["data"]?["resources"]?["nodes"]?.AsArray();
+
+                if (nodes != null) {
+                    foreach (var node in nodes) {
+                        if (node != null)
+                            resources.Add(WizResource.FromJson(node));
+                    }
+                }
+
+                var pageInfo = jsonResponse["data"]?["resources"]?["pageInfo"];
+                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+                return (resources, hasNextPage, endCursor);
+            }
+        }
+    }
+
+    /// <summary>
     /// Releases all resources used by the WizClient.
     /// </summary>
     public void Dispose() {


### PR DESCRIPTION
## Summary
- support ResourcesQuery in GraphQl queries
- add WizResource model with issue counts
- implement resource retrieval methods in `WizClient`
- introduce `Get-WizResource` PowerShell cmdlet
- provide example script for fetching resources
- add MSTest coverage for new features

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688d0224a694832eb56740805f26d8a4