### PR TITLE
Add vulnerability retrieval and cmdlet

### DIFF
--- a/Module/Examples/GetVulnerabilities.ps1
+++ b/Module/Examples/GetVulnerabilities.ps1
@@ -1,0 +1,18 @@
+# Import the WizCloud module
+Import-Module $PSScriptRoot\..\WizCloud.psd1 -Force
+
+# Connect to Wiz
+$connectWizSplat = @{
+    ClientId       = $Env:WizClientID
+    ClientSecret   = $Env:WizClientSecret
+    TestConnection = $true
+    Region         = 'eu17'
+}
+Connect-Wiz @connectWizSplat
+
+# Get vulnerabilities
+Write-Host "`nRetrieving vulnerabilities..." -ForegroundColor Yellow
+$vulnerabilities = Get-WizVulnerability -Verbose -MaxResults 50
+Write-Host "`nFound $($vulnerabilities.Count) vulnerabilities" -ForegroundColor Green
+$vulnerabilities | Select-Object Id, Cve, @{Name='Cvss';Expression={$_.Cvss.Score}}, ExploitAvailable | Format-Table
+

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizVulnerability.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizVulnerability.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Management.Automation;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WizCloud;
+
+namespace WizCloud.PowerShell;
+
+/// <summary>
+/// <para type="synopsis">Gets vulnerabilities from Wiz.io.</para>
+/// <para type="description">The Get-WizVulnerability cmdlet retrieves vulnerabilities from Wiz.io using streaming enumeration.</para>
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "WizVulnerability")]
+[OutputType(typeof(WizVulnerability))]
+public class CmdletGetWizVulnerability : AsyncPSCmdlet {
+    /// <summary>
+    /// <para type="description">The number of vulnerabilities to retrieve per page. Default is 500.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, HelpMessage = "The number of vulnerabilities to retrieve per page.")]
+    [ValidateRange(1, 5000)]
+    public int PageSize { get; set; } = 500;
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by CVE identifier.")]
+    public string? CVE { get; set; }
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by minimum CVSS score.")]
+    public double? MinCVSS { get; set; }
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter to vulnerabilities with an available exploit.")]
+    public SwitchParameter ExploitAvailable { get; set; }
+
+    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    public string? ProjectId { get; set; }
+
+    /// <summary>
+    /// <para type="description">The maximum number of vulnerabilities to retrieve. Default is unlimited.</para>
+    /// </summary>
+    [Parameter(Mandatory = false, HelpMessage = "Maximum number of vulnerabilities to retrieve. Default is unlimited.")]
+    [ValidateRange(1, int.MaxValue)]
+    public int? MaxResults { get; set; }
+
+    private WizClient? _wizClient;
+    private int _retrievedCount = 0;
+
+    /// <summary>
+    /// Initialize the Wiz client.
+    /// </summary>
+    protected override Task BeginProcessingAsync() {
+        try {
+            var token = ModuleInitialization.DefaultToken;
+            if (string.IsNullOrEmpty(token)) {
+                WriteError(new ErrorRecord(
+                    new InvalidOperationException("No authentication found. Please use Connect-Wiz first."),
+                    "NoTokenAvailable",
+                    ErrorCategory.AuthenticationError,
+                    null));
+                return Task.CompletedTask;
+            }
+
+            WriteVerbose("Using stored token from Connect-Wiz");
+            var region = ModuleInitialization.DefaultRegion;
+            WriteVerbose($"Using region from Connect-Wiz: {region}");
+
+            var clientId = ModuleInitialization.DefaultClientId;
+            var clientSecret = ModuleInitialization.DefaultClientSecret;
+
+            _wizClient = !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret)
+                ? new WizClient(token, region, clientId, clientSecret)
+                : new WizClient(token, region);
+            WriteVerbose($"Connected to Wiz region: {region}");
+        } catch (HttpRequestException ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizApiHttpError",
+                ErrorCategory.ConnectionError,
+                null));
+        } catch (Exception ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizClientInitializationError",
+                ErrorCategory.ConnectionError,
+                null));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Retrieve and output Wiz vulnerabilities.
+    /// </summary>
+    protected override async Task ProcessRecordAsync() {
+        if (_wizClient == null) {
+            WriteError(new ErrorRecord(
+                new InvalidOperationException("Wiz client is not initialized"),
+                "WizClientNotInitialized",
+                ErrorCategory.InvalidOperation,
+                null));
+            return;
+        }
+
+        try {
+            WriteVerbose($"Retrieving Wiz vulnerabilities with page size: {PageSize}" +
+                (MaxResults.HasValue ? $", max results: {MaxResults.Value}" : ""));
+
+            var progressRecord = new ProgressRecord(1, "Get-WizVulnerability", "Retrieving vulnerabilities from Wiz...");
+            WriteProgress(progressRecord);
+
+            await foreach (var vulnerability in _wizClient.GetVulnerabilitiesAsyncEnumerable(
+                PageSize,
+                CVE,
+                MinCVSS,
+                ExploitAvailable.IsPresent ? true : (bool?)null,
+                ProjectId,
+                CancelToken)) {
+                if (CancelToken.IsCancellationRequested)
+                    break;
+
+                WriteObject(vulnerability);
+                _retrievedCount++;
+
+                if (MaxResults.HasValue) {
+                    var percentComplete = (int)((double)_retrievedCount / MaxResults.Value * 100);
+                    progressRecord.StatusDescription = $"Retrieved {_retrievedCount} of {MaxResults.Value} vulnerabilities...";
+                    progressRecord.PercentComplete = percentComplete;
+                    WriteProgress(progressRecord);
+                } else if (_retrievedCount % 100 == 0) {
+                    progressRecord.StatusDescription = $"Retrieved {_retrievedCount} vulnerabilities...";
+                    WriteProgress(progressRecord);
+                }
+
+                if (MaxResults.HasValue && _retrievedCount >= MaxResults.Value) {
+                    WriteVerbose($"Reached maximum result limit of {MaxResults.Value} vulnerabilities");
+                    break;
+                }
+            }
+
+            progressRecord.StatusDescription = "Completed";
+            progressRecord.PercentComplete = 100;
+            progressRecord.RecordType = ProgressRecordType.Completed;
+            WriteProgress(progressRecord);
+        } catch (HttpRequestException ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizApiHttpError",
+                ErrorCategory.ReadError,
+                null));
+        } catch (Exception ex) {
+            WriteError(new ErrorRecord(
+                ex,
+                "WizVulnerabilityRetrievalError",
+                ErrorCategory.ReadError,
+                null));
+        }
+    }
+
+    /// <summary>
+    /// Clean up resources.
+    /// </summary>
+    protected override Task EndProcessingAsync() {
+        _wizClient?.Dispose();
+        return Task.CompletedTask;
+    }
+}
+

--- a/WizCloud.Tests/GetVulnerabilitiesAsyncEnumerableTests.cs
+++ b/WizCloud.Tests/GetVulnerabilitiesAsyncEnumerableTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetVulnerabilitiesAsyncEnumerableTests {
+    [TestMethod]
+    public void MethodExistsWithCorrectReturnType() {
+        var method = typeof(WizClient).GetMethod("GetVulnerabilitiesAsyncEnumerable");
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(IAsyncEnumerable<WizVulnerability>), method!.ReturnType);
+    }
+
+    [TestMethod]
+    public void MethodContainsErrorHandling() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
+        var source = File.ReadAllText(filePath);
+        var index = source.IndexOf("GetVulnerabilitiesAsyncEnumerable", StringComparison.Ordinal);
+        Assert.IsTrue(index >= 0, "GetVulnerabilitiesAsyncEnumerable method not found");
+        var snippet = source.Substring(index, Math.Min(1200, source.Length - index));
+        StringAssert.Contains(snippet, "catch (HttpRequestException)");
+        StringAssert.Contains(snippet, "yield break");
+    }
+}
+

--- a/WizCloud.Tests/GetVulnerabilitiesAsyncTests.cs
+++ b/WizCloud.Tests/GetVulnerabilitiesAsyncTests.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetVulnerabilitiesAsyncTests {
+    [TestMethod]
+    public void MethodExistsWithCorrectReturnType() {
+        var method = typeof(WizClient).GetMethod("GetVulnerabilitiesAsync");
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(Task<List<WizVulnerability>>), method!.ReturnType);
+    }
+}
+

--- a/WizCloud.Tests/GetWizVulnerabilityTests.cs
+++ b/WizCloud.Tests/GetWizVulnerabilityTests.cs
@@ -1,0 +1,17 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetWizVulnerabilityTests {
+    [TestMethod]
+    public void ProgressRecordSetToCompleted() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud.PowerShell", "Cmdlets", "CmdletGetWizVulnerability.cs");
+        var source = File.ReadAllText(filePath);
+        StringAssert.Contains(source, "RecordType = ProgressRecordType.Completed");
+    }
+}
+

--- a/WizCloud.Tests/GraphQlQueriesTests.cs
+++ b/WizCloud.Tests/GraphQlQueriesTests.cs
@@ -44,4 +44,12 @@ public sealed class GraphQlQueriesTests {
         Assert.IsNotNull(field);
         Assert.AreEqual(typeof(string), field!.FieldType);
     }
+
+    [TestMethod]
+    public void VulnerabilitiesQuery_ConstantExists() {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.Static;
+        var field = typeof(GraphQlQueries).GetField("VulnerabilitiesQuery", flags);
+        Assert.IsNotNull(field);
+        Assert.AreEqual(typeof(string), field!.FieldType);
+    }
 }

--- a/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
+++ b/WizCloud.Tests/WizClientGraphQlQueriesTests.cs
@@ -12,9 +12,10 @@ public sealed class WizClientGraphQlQueriesTests {
         var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
         var source = File.ReadAllText(filePath);
         StringAssert.Contains(source, "GraphQlQueries.UsersQuery");
-        StringAssert.Contains(source, "GraphQlQueries.ProjectsQuery");
-        StringAssert.Contains(source, "GraphQlQueries.CloudAccountsQuery");
-        StringAssert.Contains(source, "GraphQlQueries.IssuesQuery");
+       StringAssert.Contains(source, "GraphQlQueries.ProjectsQuery");
+       StringAssert.Contains(source, "GraphQlQueries.CloudAccountsQuery");
+       StringAssert.Contains(source, "GraphQlQueries.IssuesQuery");
+        StringAssert.Contains(source, "GraphQlQueries.VulnerabilitiesQuery");
         StringAssert.Contains(source, "GraphQlQueries.ResourcesQuery");
     }
 }

--- a/WizCloud/GraphQlQueries.cs
+++ b/WizCloud/GraphQlQueries.cs
@@ -83,6 +83,40 @@ public static class GraphQlQueries {
         }";
 
     /// <summary>
+    /// Query for retrieving vulnerabilities.
+    /// </summary>
+    public const string VulnerabilitiesQuery = @"query Vulnerabilities($first: Int, $after: String, $filterBy: VulnerabilityFilters) {
+            vulnerabilities(first: $first, after: $after, filterBy: $filterBy) {
+                pageInfo { hasNextPage endCursor }
+                nodes {
+                    id
+                    cve
+                    cvss {
+                        score
+                        severity
+                        vector
+                    }
+                    publishedDate
+                    modifiedDate
+                    description
+                    affectedPackages {
+                        name
+                        version
+                        fixVersion
+                    }
+                    resources {
+                        id
+                        name
+                        type
+                        cloudPlatform
+                    }
+                    exploitAvailable
+                    exploitInTheWild
+                }
+            }
+        }";
+
+    /// <summary>
     /// Query for retrieving cloud resources.
     /// </summary>
     public const string ResourcesQuery = @"query Resources($first: Int, $after: String, $filterBy: ResourceFilters) {

--- a/WizCloud/Models/WizVulnerability.cs
+++ b/WizCloud/Models/WizVulnerability.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Nodes;
+
+namespace WizCloud;
+
+/// <summary>
+/// Represents a vulnerability finding returned by the Wiz API.
+/// </summary>
+public class WizVulnerability {
+    /// <summary>
+    /// Gets or sets the unique identifier of the vulnerability.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the CVE identifier.
+    /// </summary>
+    public string Cve { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the CVSS information.
+    /// </summary>
+    public WizVulnerabilityCvss? Cvss { get; set; }
+
+    /// <summary>
+    /// Gets or sets the published date of the vulnerability.
+    /// </summary>
+    public DateTime? PublishedDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last modified date of the vulnerability.
+    /// </summary>
+    public DateTime? ModifiedDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description of the vulnerability.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of affected packages.
+    /// </summary>
+    public List<WizVulnerabilityPackage> AffectedPackages { get; set; } = new List<WizVulnerabilityPackage>();
+
+    /// <summary>
+    /// Gets or sets the list of affected resources.
+    /// </summary>
+    public List<WizVulnerabilityResource> Resources { get; set; } = new List<WizVulnerabilityResource>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an exploit is available.
+    /// </summary>
+    public bool? ExploitAvailable { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether an exploit exists in the wild.
+    /// </summary>
+    public bool? ExploitInTheWild { get; set; }
+
+    /// <summary>
+    /// Creates a <see cref="WizVulnerability"/> from JSON.
+    /// </summary>
+    public static WizVulnerability FromJson(JsonNode node) {
+        var vulnerability = new WizVulnerability {
+            Id = node["id"]?.GetValue<string>() ?? string.Empty,
+            Cve = node["cve"]?.GetValue<string>() ?? string.Empty,
+            PublishedDate = node["publishedDate"]?.GetValue<DateTime?>()?.ToLocalTime(),
+            ModifiedDate = node["modifiedDate"]?.GetValue<DateTime?>()?.ToLocalTime(),
+            Description = node["description"]?.GetValue<string>(),
+            ExploitAvailable = node["exploitAvailable"]?.GetValue<bool?>(),
+            ExploitInTheWild = node["exploitInTheWild"]?.GetValue<bool?>()
+        };
+
+        var cvssNode = node["cvss"];
+        if (cvssNode != null) {
+            vulnerability.Cvss = WizVulnerabilityCvss.FromJson(cvssNode);
+        }
+
+        var packages = node["affectedPackages"]?.AsArray();
+        if (packages != null) {
+            foreach (var pkg in packages) {
+                if (pkg != null) {
+                    vulnerability.AffectedPackages.Add(WizVulnerabilityPackage.FromJson(pkg));
+                }
+            }
+        }
+
+        var resources = node["resources"]?.AsArray();
+        if (resources != null) {
+            foreach (var res in resources) {
+                if (res != null) {
+                    vulnerability.Resources.Add(WizVulnerabilityResource.FromJson(res));
+                }
+            }
+        }
+
+        return vulnerability;
+    }
+}
+

--- a/WizCloud/Models/WizVulnerabilityCvss.cs
+++ b/WizCloud/Models/WizVulnerabilityCvss.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace WizCloud;
+
+/// <summary>
+/// Represents CVSS information for a vulnerability.
+/// </summary>
+public class WizVulnerabilityCvss {
+    /// <summary>
+    /// Gets or sets the CVSS score.
+    /// </summary>
+    public double? Score { get; set; }
+
+    /// <summary>
+    /// Gets or sets the CVSS severity.
+    /// </summary>
+    public WizSeverity? Severity { get; set; }
+
+    /// <summary>
+    /// Gets or sets the CVSS vector.
+    /// </summary>
+    public string? Vector { get; set; }
+
+    /// <summary>
+    /// Creates a <see cref="WizVulnerabilityCvss"/> from JSON.
+    /// </summary>
+    public static WizVulnerabilityCvss FromJson(JsonNode node) {
+        return new WizVulnerabilityCvss {
+            Score = node["score"]?.GetValue<double?>(),
+            Severity = Enum.TryParse(node["severity"]?.GetValue<string>(), true, out WizSeverity tmpSev) ? tmpSev : null,
+            Vector = node["vector"]?.GetValue<string>()
+        };
+    }
+}
+

--- a/WizCloud/Models/WizVulnerabilityPackage.cs
+++ b/WizCloud/Models/WizVulnerabilityPackage.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Nodes;
+
+namespace WizCloud;
+
+/// <summary>
+/// Represents a package affected by a vulnerability.
+/// </summary>
+public class WizVulnerabilityPackage {
+    /// <summary>
+    /// Gets or sets the package name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the package version.
+    /// </summary>
+    public string? Version { get; set; }
+
+    /// <summary>
+    /// Gets or sets the fix version for the package.
+    /// </summary>
+    public string? FixVersion { get; set; }
+
+    /// <summary>
+    /// Creates a <see cref="WizVulnerabilityPackage"/> from JSON.
+    /// </summary>
+    public static WizVulnerabilityPackage FromJson(JsonNode node) {
+        return new WizVulnerabilityPackage {
+            Name = node["name"]?.GetValue<string>() ?? string.Empty,
+            Version = node["version"]?.GetValue<string>(),
+            FixVersion = node["fixVersion"]?.GetValue<string>()
+        };
+    }
+}
+

--- a/WizCloud/Models/WizVulnerabilityResource.cs
+++ b/WizCloud/Models/WizVulnerabilityResource.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Text.Json.Nodes;
+
+namespace WizCloud;
+
+/// <summary>
+/// Represents a resource affected by a vulnerability.
+/// </summary>
+public class WizVulnerabilityResource {
+    /// <summary>
+    /// Gets or sets the unique identifier of the resource.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the name of the resource.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the type of the resource.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the cloud platform hosting the resource.
+    /// </summary>
+    public WizCloudProvider? CloudPlatform { get; set; }
+
+    /// <summary>
+    /// Creates a <see cref="WizVulnerabilityResource"/> from JSON.
+    /// </summary>
+    public static WizVulnerabilityResource FromJson(JsonNode node) {
+        return new WizVulnerabilityResource {
+            Id = node["id"]?.GetValue<string>() ?? string.Empty,
+            Name = node["name"]?.GetValue<string>() ?? string.Empty,
+            Type = node["type"]?.GetValue<string>() ?? string.Empty,
+            CloudPlatform = Enum.TryParse(node["cloudPlatform"]?.GetValue<string>(), true, out WizCloudProvider tmpCp) ? tmpCp : null
+        };
+    }
+}
+

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -563,6 +563,145 @@ public class WizClient : IDisposable {
     }
 
     /// <summary>
+    /// Retrieves all vulnerabilities from Wiz asynchronously.
+    /// </summary>
+    public async Task<List<WizVulnerability>> GetVulnerabilitiesAsync(
+        int pageSize = 20,
+        string? cve = null,
+        double? minCvss = null,
+        bool? exploitAvailable = null,
+        string? projectId = null) {
+        var vulnerabilities = new List<WizVulnerability>();
+        string? endCursor = null;
+        bool hasNextPage = true;
+
+        while (hasNextPage) {
+            var result = await GetVulnerabilitiesPageAsync(
+                pageSize,
+                endCursor,
+                cve,
+                minCvss,
+                exploitAvailable,
+                projectId).ConfigureAwait(false);
+            vulnerabilities.AddRange(result.Vulnerabilities);
+            hasNextPage = result.HasNextPage;
+            endCursor = result.EndCursor;
+        }
+
+        return vulnerabilities;
+    }
+
+    /// <summary>
+    /// Streams vulnerabilities from Wiz asynchronously.
+    /// </summary>
+    public async IAsyncEnumerable<WizVulnerability> GetVulnerabilitiesAsyncEnumerable(
+        int pageSize = 20,
+        string? cve = null,
+        double? minCvss = null,
+        bool? exploitAvailable = null,
+        string? projectId = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+        string? endCursor = null;
+        bool hasNextPage = true;
+
+        while (!cancellationToken.IsCancellationRequested && hasNextPage) {
+            (List<WizVulnerability> Vulnerabilities, bool HasNextPage, string? EndCursor) result;
+            try {
+                result = await GetVulnerabilitiesPageAsync(
+                    pageSize,
+                    endCursor,
+                    cve,
+                    minCvss,
+                    exploitAvailable,
+                    projectId).ConfigureAwait(false);
+            } catch (HttpRequestException) {
+                yield break;
+            }
+
+            foreach (var vulnerability in result.Vulnerabilities) {
+                if (cancellationToken.IsCancellationRequested)
+                    yield break;
+
+                yield return vulnerability;
+            }
+
+            hasNextPage = result.HasNextPage;
+            endCursor = result.EndCursor;
+        }
+    }
+
+    /// <summary>
+    /// Retrieves a single page of vulnerabilities from the Wiz API.
+    /// </summary>
+    private async Task<(List<WizVulnerability> Vulnerabilities, bool HasNextPage, string? EndCursor)> GetVulnerabilitiesPageAsync(
+        int first,
+        string? after = null,
+        string? cve = null,
+        double? minCvss = null,
+        bool? exploitAvailable = null,
+        string? projectId = null) {
+        const string query = GraphQlQueries.VulnerabilitiesQuery;
+
+        var cveFilter = cve != null ? new { equals = new[] { cve } } : null;
+        var cvssFilter = minCvss != null ? new { score = new { gte = minCvss } } : null;
+        var exploitFilter = exploitAvailable.HasValue ? new { equals = exploitAvailable.Value } : null;
+        var projectFilter = projectId != null ? new { equals = new[] { projectId } } : null;
+
+        var variables = new {
+            first,
+            after,
+            filterBy = new {
+                cve = cveFilter,
+                cvss = cvssFilter,
+                exploitAvailable = exploitFilter,
+                projectId = projectFilter
+            }
+        };
+
+        var requestBody = new { query, variables };
+
+        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
+            request.Content = new StringContent(
+                JsonSerializer.Serialize(requestBody),
+                Encoding.UTF8,
+                "application/json"
+            );
+
+            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
+                if (!response.IsSuccessStatusCode) {
+                    var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    var message = $"Request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase}).";
+                    if (!string.IsNullOrWhiteSpace(errorBody))
+                        message += $" Body: {errorBody}";
+                    throw new HttpRequestException(message);
+                }
+
+                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var jsonResponse = JsonNode.Parse(content);
+
+                if (jsonResponse == null)
+                    throw new InvalidOperationException("Received null response from API");
+
+                var vulnerabilities = new List<WizVulnerability>();
+                var nodes = jsonResponse["data"]?["vulnerabilities"]?["nodes"]?.AsArray();
+
+                if (nodes != null) {
+                    foreach (var node in nodes) {
+                        if (node != null)
+                            vulnerabilities.Add(WizVulnerability.FromJson(node));
+                    }
+                }
+
+                var pageInfo = jsonResponse["data"]?["vulnerabilities"]?["pageInfo"];
+                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+                return (vulnerabilities, hasNextPage, endCursor);
+            }
+        }
+    }
+
+    /// <summary>
     /// Retrieves all resources from Wiz asynchronously.
     /// </summary>
     public async Task<List<WizResource>> GetResourcesAsync(


### PR DESCRIPTION
## Summary
- add GraphQL query and models for vulnerabilities
- support fetching vulnerabilities via WizClient and Get-WizVulnerability cmdlet
- include example script and unit tests

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688e573538e8832ebd4c456013b5ac40