### PR TITLE
Add unit tests for models and cloud account cmdlet

### DIFF
--- a/Module/Tests/GetWizCloudAccount.Tests.ps1
+++ b/Module/Tests/GetWizCloudAccount.Tests.ps1
@@ -1,0 +1,20 @@
+Describe 'Get-WizCloudAccount cmdlet' {
+    It 'streams results using await foreach' {
+        $repoRoot = Resolve-Path -Path "$PSScriptRoot/../.."
+        $source = Get-Content -Path (Join-Path $repoRoot 'WizCloud.PowerShell/Cmdlets/CmdletGetWizCloudAccount.cs') -Raw
+        $source | Should -Match 'await foreach'
+    }
+
+    It 'handles HttpRequestException' {
+        $repoRoot = Resolve-Path -Path "$PSScriptRoot/../.."
+        $source = Get-Content -Path (Join-Path $repoRoot 'WizCloud.PowerShell/Cmdlets/CmdletGetWizCloudAccount.cs') -Raw
+        $source | Should -Match 'HttpRequestException'
+    }
+
+    It 'defines PageSize and MaxResults parameters' {
+        $repoRoot = Resolve-Path -Path "$PSScriptRoot/../.."
+        $source = Get-Content -Path (Join-Path $repoRoot 'WizCloud.PowerShell/Cmdlets/CmdletGetWizCloudAccount.cs') -Raw
+        $source | Should -Match 'PageSize'
+        $source | Should -Match 'MaxResults'
+    }
+}

--- a/WizCloud.Tests/GetWizCloudAccountTests.cs
+++ b/WizCloud.Tests/GetWizCloudAccountTests.cs
@@ -1,0 +1,15 @@
+using System;
+using System.IO;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class GetWizCloudAccountTests {
+    [TestMethod]
+    public void ProgressRecordSetToCompleted() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud.PowerShell", "Cmdlets", "CmdletGetWizCloudAccount.cs");
+        var source = File.ReadAllText(filePath);
+        StringAssert.Contains(source, "RecordType = ProgressRecordType.Completed");
+    }
+}

--- a/WizCloud.Tests/WizCloudAccountTests.cs
+++ b/WizCloud.Tests/WizCloudAccountTests.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizCloudAccountTests {
+    [TestMethod]
+    public void FromJson_ParsesFields() {
+        string jsonString = """
+        {
+          "id": "acc1",
+          "name": "Account 1",
+          "cloudProvider": "AWS",
+          "externalId": "123456789012"
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizCloudAccount account = WizCloudAccount.FromJson(json);
+
+        Assert.AreEqual("acc1", account.Id);
+        Assert.AreEqual("Account 1", account.Name);
+        Assert.AreEqual("AWS", account.CloudProvider);
+        Assert.AreEqual("123456789012", account.ExternalId);
+    }
+}

--- a/WizCloud.Tests/WizIssueControlTests.cs
+++ b/WizCloud.Tests/WizIssueControlTests.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizIssueControlTests {
+    [TestMethod]
+    public void FromJson_ParsesFields() {
+        string jsonString = """
+        {
+          "id": "ctrl1",
+          "name": "Control",
+          "description": "desc",
+          "severity": "HIGH"
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizIssueControl control = WizIssueControl.FromJson(json);
+
+        Assert.AreEqual("ctrl1", control.Id);
+        Assert.AreEqual("Control", control.Name);
+        Assert.AreEqual("desc", control.Description);
+        Assert.AreEqual(WizSeverity.HIGH, control.Severity);
+    }
+}

--- a/WizCloud.Tests/WizIssueResourceTests.cs
+++ b/WizCloud.Tests/WizIssueResourceTests.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizIssueResourceTests {
+    [TestMethod]
+    public void FromJson_ParsesFields() {
+        string jsonString = """
+        {
+          "id": "res1",
+          "name": "Resource",
+          "type": "VM",
+          "cloudPlatform": "AWS",
+          "region": "us-east-1",
+          "subscriptionId": "sub1"
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizIssueResource resource = WizIssueResource.FromJson(json);
+
+        Assert.AreEqual("res1", resource.Id);
+        Assert.AreEqual("Resource", resource.Name);
+        Assert.AreEqual("VM", resource.Type);
+        Assert.AreEqual(WizCloudProvider.AWS, resource.CloudPlatform);
+        Assert.AreEqual("us-east-1", resource.Region);
+        Assert.AreEqual("sub1", resource.SubscriptionId);
+    }
+}

--- a/WizCloud.Tests/WizIssueTests.cs
+++ b/WizCloud.Tests/WizIssueTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizIssueTests {
+    [TestMethod]
+    public void FromJson_ParsesNestedObjects() {
+        string jsonString = """
+        {
+          "id": "iss1",
+          "name": "Issue",
+          "type": "VULNERABILITY",
+          "severity": "MEDIUM",
+          "status": "OPEN",
+          "createdAt": "2024-05-01T00:00:00Z",
+          "projects": [{ "id": "p1", "name": "Project" }],
+          "resource": {
+            "id": "res1",
+            "name": "Resource",
+            "type": "VM",
+            "cloudPlatform": "AWS"
+          },
+          "control": {
+            "id": "ctrl1",
+            "name": "Control",
+            "severity": "LOW"
+          },
+          "evidence": "evidence",
+          "remediation": "fix"
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizIssue issue = WizIssue.FromJson(json);
+
+        Assert.AreEqual("iss1", issue.Id);
+        Assert.AreEqual("Issue", issue.Name);
+        Assert.AreEqual("VULNERABILITY", issue.Type);
+        Assert.AreEqual(WizSeverity.MEDIUM, issue.Severity);
+        Assert.AreEqual("OPEN", issue.Status);
+        Assert.AreEqual(DateTime.Parse("2024-05-01T00:00:00Z").ToLocalTime(), issue.CreatedAt);
+        Assert.AreEqual(1, issue.Projects.Count);
+        Assert.IsNotNull(issue.Resource);
+        Assert.AreEqual("res1", issue.Resource!.Id);
+        Assert.IsNotNull(issue.Control);
+        Assert.AreEqual(WizSeverity.LOW, issue.Control!.Severity);
+        Assert.AreEqual("evidence", issue.Evidence);
+        Assert.AreEqual("fix", issue.Remediation);
+    }
+}

--- a/WizCloud.Tests/WizResourceIssueCountsTests.cs
+++ b/WizCloud.Tests/WizResourceIssueCountsTests.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizResourceIssueCountsTests {
+    [TestMethod]
+    public void FromJson_ParsesCounts() {
+        string jsonString = """
+        {
+          "criticalCount": 1,
+          "highCount": 2,
+          "mediumCount": 3,
+          "lowCount": 4
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizResourceIssueCounts counts = WizResourceIssueCounts.FromJson(json);
+
+        Assert.AreEqual(1, counts.CriticalCount);
+        Assert.AreEqual(2, counts.HighCount);
+        Assert.AreEqual(3, counts.MediumCount);
+        Assert.AreEqual(4, counts.LowCount);
+    }
+}

--- a/WizCloud.Tests/WizResourceTests.cs
+++ b/WizCloud.Tests/WizResourceTests.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizResourceTests {
+    [TestMethod]
+    public void FromJson_ParsesAllFields() {
+        string jsonString = """
+        {
+          "id": "res1",
+          "name": "Resource 1",
+          "type": "VM",
+          "nativeType": "virtualMachine",
+          "cloudPlatform": "Azure",
+          "region": "eastus",
+          "createdAt": "2024-01-01T00:00:00Z",
+          "status": "Active",
+          "publiclyAccessible": true,
+          "hasPublicIpAddress": false,
+          "isInternetFacing": true,
+          "tags": { "env": "prod" },
+          "cloudAccount": {
+            "id": "acc1",
+            "name": "Account",
+            "cloudProvider": "Azure",
+            "externalId": "sub1"
+          },
+          "securityGroups": ["sg-1", "sg-2"],
+          "issues": {
+            "criticalCount": 1,
+            "highCount": 2,
+            "mediumCount": 3,
+            "lowCount": 4
+          }
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizResource resource = WizResource.FromJson(json);
+
+        Assert.AreEqual("res1", resource.Id);
+        Assert.AreEqual("Resource 1", resource.Name);
+        Assert.AreEqual("VM", resource.Type);
+        Assert.AreEqual("virtualMachine", resource.NativeType);
+        Assert.AreEqual(WizCloudProvider.AZURE, resource.CloudPlatform);
+        Assert.AreEqual("eastus", resource.Region);
+        Assert.AreEqual(DateTime.Parse("2024-01-01T00:00:00Z").ToLocalTime(), resource.CreatedAt);
+        Assert.AreEqual("Active", resource.Status);
+        Assert.IsTrue(resource.PubliclyAccessible);
+        Assert.IsFalse(resource.HasPublicIpAddress);
+        Assert.IsTrue(resource.IsInternetFacing);
+        Assert.AreEqual("prod", resource.Tags["env"]);
+        Assert.IsNotNull(resource.CloudAccount);
+        Assert.AreEqual("acc1", resource.CloudAccount!.Id);
+        Assert.AreEqual(2, resource.SecurityGroups.Count);
+        Assert.IsNotNull(resource.Issues);
+        Assert.AreEqual(1, resource.Issues!.CriticalCount);
+    }
+}

--- a/WizCloud.Tests/WizVulnerabilityCvssTests.cs
+++ b/WizCloud.Tests/WizVulnerabilityCvssTests.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizVulnerabilityCvssTests {
+    [TestMethod]
+    public void FromJson_ParsesFields() {
+        string jsonString = """
+        {
+          "score": 9.8,
+          "severity": "CRITICAL",
+          "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizVulnerabilityCvss cvss = WizVulnerabilityCvss.FromJson(json);
+
+        Assert.AreEqual(9.8, cvss.Score);
+        Assert.AreEqual(WizSeverity.CRITICAL, cvss.Severity);
+        Assert.AreEqual("AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", cvss.Vector);
+    }
+}

--- a/WizCloud.Tests/WizVulnerabilityPackageTests.cs
+++ b/WizCloud.Tests/WizVulnerabilityPackageTests.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizVulnerabilityPackageTests {
+    [TestMethod]
+    public void FromJson_ParsesFields() {
+        string jsonString = """
+        {
+          "name": "pkg",
+          "version": "1.0",
+          "fixVersion": "1.1"
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizVulnerabilityPackage package = WizVulnerabilityPackage.FromJson(json);
+
+        Assert.AreEqual("pkg", package.Name);
+        Assert.AreEqual("1.0", package.Version);
+        Assert.AreEqual("1.1", package.FixVersion);
+    }
+}

--- a/WizCloud.Tests/WizVulnerabilityResourceTests.cs
+++ b/WizCloud.Tests/WizVulnerabilityResourceTests.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizVulnerabilityResourceTests {
+    [TestMethod]
+    public void FromJson_ParsesFields() {
+        string jsonString = """
+        {
+          "id": "res1",
+          "name": "Resource",
+          "type": "VM",
+          "cloudPlatform": "GCP"
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizVulnerabilityResource resource = WizVulnerabilityResource.FromJson(json);
+
+        Assert.AreEqual("res1", resource.Id);
+        Assert.AreEqual("Resource", resource.Name);
+        Assert.AreEqual("VM", resource.Type);
+        Assert.AreEqual(WizCloudProvider.GCP, resource.CloudPlatform);
+    }
+}

--- a/WizCloud.Tests/WizVulnerabilityTests.cs
+++ b/WizCloud.Tests/WizVulnerabilityTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Text.Json.Nodes;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizVulnerabilityTests {
+    [TestMethod]
+    public void FromJson_ParsesNestedObjects() {
+        string jsonString = """
+        {
+          "id": "vul1",
+          "cve": "CVE-2024-0001",
+          "publishedDate": "2024-01-01T00:00:00Z",
+          "modifiedDate": "2024-02-01T00:00:00Z",
+          "description": "desc",
+          "exploitAvailable": true,
+          "exploitInTheWild": false,
+          "cvss": {
+            "score": 7.5,
+            "severity": "HIGH",
+            "vector": "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+          },
+          "affectedPackages": [
+            { "name": "pkg", "version": "1.0", "fixVersion": "1.1" }
+          ],
+          "resources": [
+            { "id": "res1", "name": "Res", "type": "VM", "cloudPlatform": "AWS" }
+          ]
+        }
+        """;
+        JsonNode json = JsonNode.Parse(jsonString)!;
+        WizVulnerability vul = WizVulnerability.FromJson(json);
+
+        Assert.AreEqual("vul1", vul.Id);
+        Assert.AreEqual("CVE-2024-0001", vul.Cve);
+        Assert.AreEqual(DateTime.Parse("2024-01-01T00:00:00Z").ToLocalTime(), vul.PublishedDate);
+        Assert.AreEqual(DateTime.Parse("2024-02-01T00:00:00Z").ToLocalTime(), vul.ModifiedDate);
+        Assert.AreEqual("desc", vul.Description);
+        Assert.IsTrue(vul.ExploitAvailable);
+        Assert.IsFalse(vul.ExploitInTheWild);
+        Assert.IsNotNull(vul.Cvss);
+        Assert.AreEqual(7.5, vul.Cvss!.Score);
+        Assert.AreEqual(1, vul.AffectedPackages.Count);
+        Assert.AreEqual("pkg", vul.AffectedPackages[0].Name);
+        Assert.AreEqual(1, vul.Resources.Count);
+        Assert.AreEqual("res1", vul.Resources[0].Id);
+    }
+}


### PR DESCRIPTION
## Summary
- add FromJson tests for cloud account, issue, vulnerability, and related models
- add tests for Get-WizCloudAccount cmdlet progress and parameters

## Testing
- `dotnet build WizCloud.sln`
- `dotnet test WizCloud.Tests/WizCloud.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_688e6b8d6fc4832eb0a38fb3611efde7