### PR TITLE
refactor: rely on SendWithRefreshAsync for auth header

### DIFF
--- a/WizCloud/WizClient.CloudAccounts.cs
+++ b/WizCloud/WizClient.CloudAccounts.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Net;
@@ -79,7 +78,6 @@ public partial class WizClient {
         };
 
         using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
             request.Content = new StringContent(
                 JsonSerializer.Serialize(requestBody),
                 Encoding.UTF8,


### PR DESCRIPTION
## Summary
- remove manual Authorization header from GetCloudAccountsPageAsync
- depend on SendWithRefreshAsync for injecting auth header

## Testing
- `dotnet build WizCloud.sln`
- `dotnet test WizCloud.Tests/WizCloud.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_688e7596e2dc832e95a85d71ef12fcf9