### PR TITLE
Use forward slashes for PowerShell project reference

### DIFF
--- a/WizCloud.PowerShell/WizCloud.PowerShell.csproj
+++ b/WizCloud.PowerShell/WizCloud.PowerShell.csproj
@@ -57,7 +57,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\WizCloud\WizCloud.csproj" />
+        <ProjectReference Include="../WizCloud/WizCloud.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- normalize WizCloud PowerShell project reference to use forward slashes for cross-platform builds

## Testing
- `dotnet build WizCloud.sln --no-restore`
- `dotnet build WizCloud.sln /p:OS=Windows_NT --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_689064ae29a0832e89c60d7f2f6bf829