### PR TITLE
feat: add async WizClient factory

### DIFF
--- a/WizCloud.Examples/Samples/ClientCredentialSample.cs
+++ b/WizCloud.Examples/Samples/ClientCredentialSample.cs
@@ -5,8 +5,7 @@ using WizCloud;
 namespace WizCloud.Examples;
 internal static class ClientCredentialSample {
     public static async Task RunAsync() {
-        var token = await WizAuthentication.AcquireTokenAsync("clientId", "clientSecret");
-        using var client = new WizClient(token);
+        using var client = await WizClient.CreateAsync("clientId", "clientSecret");
         var users = await client.GetUsersAsync(pageSize: 1);
         Console.WriteLine($"Client credentials sample retrieved {users.Count} user(s).");
         if (users.Count > 0) {

--- a/WizCloud.Tests/WizClientFactoryTests.cs
+++ b/WizCloud.Tests/WizClientFactoryTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using WizCloud;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+public sealed class WizClientFactoryTests {
+    [TestMethod]
+    public void CreateAsync_ReturnsTaskOfWizClient() {
+        var method = typeof(WizClient).GetMethod(
+            "CreateAsync",
+            new[] { typeof(string), typeof(string), typeof(WizRegion) });
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(Task<WizClient>), method!.ReturnType);
+    }
+
+    [TestMethod]
+    public void CreateAsync_UsesAcquireTokenAsync() {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var filePath = Path.Combine(repoRoot, "WizCloud", "WizClient.cs");
+        var source = File.ReadAllText(filePath);
+        var methodIndex = source.IndexOf("CreateAsync(string clientId, string clientSecret", StringComparison.Ordinal);
+        Assert.IsTrue(methodIndex >= 0, "CreateAsync method not found");
+        var callIndex = source.IndexOf("AcquireTokenAsync", methodIndex, StringComparison.Ordinal);
+        Assert.IsTrue(callIndex >= 0, "AcquireTokenAsync not used in CreateAsync");
+    }
+}

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -50,28 +50,26 @@ public partial class WizClient : IDisposable {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="WizClient"/> class using client credentials.
-    /// </summary>
-    /// <summary>
-    /// Initializes a new instance of the <see cref="WizClient"/> class using client credentials.
+    /// Creates a new instance of the <see cref="WizClient"/> class using client credentials.
     /// </summary>
     /// <param name="clientId">The Wiz service account client ID.</param>
     /// <param name="clientSecret">The Wiz service account client secret.</param>
     /// <param name="region">The Wiz region enumeration value.</param>
-    public WizClient(string clientId, string clientSecret, WizRegion region)
-        : this(AcquireToken(clientId, clientSecret, region), region, clientId, clientSecret) { }
+    /// <returns>A <see cref="WizClient"/> instance authenticated with the retrieved token.</returns>
+    public static async Task<WizClient> CreateAsync(string clientId, string clientSecret, WizRegion region = WizRegion.EU17) {
+        var token = await WizAuthentication.AcquireTokenAsync(clientId, clientSecret, region).ConfigureAwait(false);
+        return new WizClient(token, region, clientId, clientSecret);
+    }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="WizClient"/> class using client credentials.
+    /// Creates a new instance of the <see cref="WizClient"/> class using client credentials and a region identifier.
     /// </summary>
     /// <param name="clientId">The Wiz service account client ID.</param>
     /// <param name="clientSecret">The Wiz service account client secret.</param>
     /// <param name="region">The Wiz region identifier.</param>
-    public WizClient(string clientId, string clientSecret, string region)
-        : this(clientId, clientSecret, WizRegionHelper.FromString(region)) { }
-
-    private static string AcquireToken(string clientId, string clientSecret, WizRegion region)
-        => WizAuthentication.AcquireTokenAsync(clientId, clientSecret, region).GetAwaiter().GetResult();
+    /// <returns>A <see cref="WizClient"/> instance authenticated with the retrieved token.</returns>
+    public static Task<WizClient> CreateAsync(string clientId, string clientSecret, string region)
+        => CreateAsync(clientId, clientSecret, WizRegionHelper.FromString(region));
 
     private async Task<HttpResponseMessage> SendWithRefreshAsync(HttpRequestMessage request) {
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);


### PR DESCRIPTION
## Summary
- replace client credential constructors with async WizClient.CreateAsync
- show ClientCredentialSample using WizClient.CreateAsync
- add tests for WizClient.CreateAsync

## Testing
- `dotnet build -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6890649e6034832e816c134d378c8f90