### PR TITLE
refactor: remove unused variable in Connect-Wiz cmdlet

### DIFF
--- a/WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs
@@ -91,9 +91,7 @@ public class CmdletConnectWiz : AsyncPSCmdlet {
                 
                 // Just test if we can make a successful API call by checking for projects
                 // We use GetProjectsAsyncEnumerable with immediate break to avoid fetching all data
-                var hasProjects = false;
-                await foreach (var project in testClient.GetProjectsAsyncEnumerable(1)) {
-                    hasProjects = true;
+                await foreach (var _ in testClient.GetProjectsAsyncEnumerable(1)) {
                     break; // Exit after first project to avoid loading all data
                 }
                 


### PR DESCRIPTION
## Summary
- remove unused hasProjects variable when testing connection

## Testing
- `dotnet build WizCloud.sln`
- `pwsh -NoLogo -File Module/WizCloud.Tests.ps1` *(fails: A parameter cannot be found that matches parameter name 'MemberName')*

------
https://chatgpt.com/codex/tasks/task_e_689064885d40832eb7f22502ae819951