### PR TITLE
Remove redundant Authorization headers

### DIFF
--- a/WizCloud/WizClient.AuditLogs.cs
+++ b/WizCloud/WizClient.AuditLogs.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Linq;
@@ -91,7 +89,6 @@ public partial class WizClient {
         var requestBody = new { query, variables };
 
         using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
             request.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
 
             using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {

--- a/WizCloud/WizClient.Compliance.cs
+++ b/WizCloud/WizClient.Compliance.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Linq;
@@ -26,7 +24,6 @@ public partial class WizClient {
         var requestBody = new { query, variables };
 
         using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
             request.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
 
             using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {

--- a/WizCloud/WizClient.ConfigurationFindings.cs
+++ b/WizCloud/WizClient.ConfigurationFindings.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Linq;
@@ -92,7 +90,6 @@ public partial class WizClient {
         var requestBody = new { query, variables };
 
         using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
             request.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
 
             using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {

--- a/WizCloud/WizClient.Issues.cs
+++ b/WizCloud/WizClient.Issues.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Linq;
@@ -107,7 +105,6 @@ public partial class WizClient {
         var requestBody = new { query, variables };
 
         using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
             request.Content = new StringContent(
                 JsonSerializer.Serialize(requestBody),
                 Encoding.UTF8,

--- a/WizCloud/WizClient.NetworkExposure.cs
+++ b/WizCloud/WizClient.NetworkExposure.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Linq;
@@ -92,7 +90,6 @@ public partial class WizClient {
         var requestBody = new { query, variables };
 
         using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
             request.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
 
             using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {

--- a/WizCloud/WizClient.Resources.cs
+++ b/WizCloud/WizClient.Resources.cs
@@ -1,10 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Linq;
@@ -131,7 +129,6 @@ public partial class WizClient {
         var requestBody = new { query, variables };
 
         using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
             request.Content = new StringContent(
                 JsonSerializer.Serialize(requestBody),
                 Encoding.UTF8,


### PR DESCRIPTION
## Summary
- stop setting Authorization header in individual WizClient requests so SendWithRefreshAsync manages bearer tokens
- remove leftover usings tied to explicit header handling

## Testing
- `dotnet build WizCloud/WizCloud.csproj -f netstandard2.0`
- `dotnet build WizCloud/WizCloud.csproj -f net472`
- `dotnet build WizCloud/WizCloud.csproj -f net8.0`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689074575c30832e9c62d18427a80691