### PR TITLE
refactor: centralize request handling

### DIFF
--- a/WizCloud.Tests/TokenRefreshTests.cs
+++ b/WizCloud.Tests/TokenRefreshTests.cs
@@ -17,14 +17,14 @@ public sealed class TokenRefreshTests {
     }
 
     [TestMethod]
-    public void GetCloudAccounts_UsesSendWithRefreshAsync() {
+    public void GetCloudAccounts_UsesSendGraphQlRequestAsync() {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var directory = Path.Combine(repoRoot, "WizCloud");
         var source = string.Concat(Directory.GetFiles(directory, "WizClient*.cs").Select(File.ReadAllText));
         var index = source.IndexOf("GetCloudAccountsPageAsync", StringComparison.Ordinal);
         Assert.IsTrue(index >= 0, "GetCloudAccountsPageAsync method not found");
-        var callIndex = source.IndexOf("SendWithRefreshAsync", index, StringComparison.Ordinal);
-        Assert.IsTrue(callIndex >= 0, "SendWithRefreshAsync not used in GetCloudAccountsPageAsync");
+        var callIndex = source.IndexOf("SendGraphQlRequestAsync", index, StringComparison.Ordinal);
+        Assert.IsTrue(callIndex >= 0, "SendGraphQlRequestAsync not used in GetCloudAccountsPageAsync");
     }
 
     [TestMethod]

--- a/WizCloud.Tests/WizClientErrorHandlingTests.cs
+++ b/WizCloud.Tests/WizClientErrorHandlingTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace WizCloud.Tests;
@@ -8,10 +9,25 @@ namespace WizCloud.Tests;
 [TestClass]
 public sealed class WizClientErrorHandlingTests {
     [TestMethod]
-    public void WizClient_ContainsDetailedErrorMessage() {
+    public void WizClient_ContainsDetailedErrorMessageInSingleLocation() {
         var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
         var directory = Path.Combine(repoRoot, "WizCloud");
-        var source = string.Concat(Directory.GetFiles(directory, "WizClient*.cs").Select(File.ReadAllText));
-        StringAssert.Contains(source, "Request failed with status code");
+        var mainFile = Path.Combine(directory, "WizClient.cs");
+        var mainSource = File.ReadAllText(mainFile);
+        StringAssert.Contains(mainSource, "Request failed with status code");
+
+        var otherFiles = Directory.GetFiles(directory, "WizClient*.cs")
+            .Where(f => !f.EndsWith("WizClient.cs", StringComparison.Ordinal));
+        foreach (var file in otherFiles)
+            Assert.IsFalse(File.ReadAllText(file).Contains("Request failed with status code"),
+                $"Error message should be centralized, but found in {Path.GetFileName(file)}");
+    }
+
+    [TestMethod]
+    public void WizClient_HasSendGraphQlRequestAsyncMethod() {
+        var method = typeof(WizClient).GetMethod(
+            "SendGraphQlRequestAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.IsNotNull(method);
     }
 }

--- a/WizCloud/WizClient.AuditLogs.cs
+++ b/WizCloud/WizClient.AuditLogs.cs
@@ -87,39 +87,21 @@ public partial class WizClient {
         };
 
         var requestBody = new { query, variables };
+        var jsonResponse = await SendGraphQlRequestAsync(requestBody).ConfigureAwait(false);
 
-        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
-
-            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
-                if (!response.IsSuccessStatusCode) {
-                    var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var message = $"Request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase}).";
-                    if (!string.IsNullOrWhiteSpace(errorBody))
-                        message += $" Body: {errorBody}";
-                    throw new HttpRequestException(message);
-                }
-
-                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var jsonResponse = JsonNode.Parse(content);
-                if (jsonResponse == null)
-                    throw new InvalidOperationException("Received null response from API");
-
-                var logs = new List<WizAuditLogEntry>();
-                var nodes = jsonResponse["data"]?["auditLogs"]?["nodes"]?.AsArray();
-                if (nodes != null) {
-                    foreach (var node in nodes) {
-                        if (node != null)
-                            logs.Add(WizAuditLogEntry.FromJson(node));
-                    }
-                }
-
-                var pageInfo = jsonResponse["data"]?["auditLogs"]?["pageInfo"];
-                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
-                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
-
-                return (logs, hasNextPage, endCursor);
+        var logs = new List<WizAuditLogEntry>();
+        var nodes = jsonResponse["data"]?["auditLogs"]?["nodes"]?.AsArray();
+        if (nodes != null) {
+            foreach (var node in nodes) {
+                if (node != null)
+                    logs.Add(WizAuditLogEntry.FromJson(node));
             }
         }
+
+        var pageInfo = jsonResponse["data"]?["auditLogs"]?["pageInfo"];
+        bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+        string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+        return (logs, hasNextPage, endCursor);
     }
 }

--- a/WizCloud/WizClient.CloudAccounts.cs
+++ b/WizCloud/WizClient.CloudAccounts.cs
@@ -77,39 +77,23 @@ public partial class WizClient {
             variables
         };
 
-        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Content = new StringContent(
-                JsonSerializer.Serialize(requestBody),
-                Encoding.UTF8,
-                "application/json"
-            );
+        var jsonResponse = await SendGraphQlRequestAsync(requestBody).ConfigureAwait(false);
 
-            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
-                response.EnsureSuccessStatusCode();
+        var accounts = new List<WizCloudAccount>();
+        var nodes = jsonResponse["data"]?["cloudAccounts"]?["nodes"]?.AsArray();
 
-                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var jsonResponse = JsonNode.Parse(content);
-
-                if (jsonResponse == null)
-                    throw new InvalidOperationException("Received null response from API");
-
-                var accounts = new List<WizCloudAccount>();
-                var nodes = jsonResponse["data"]?["cloudAccounts"]?["nodes"]?.AsArray();
-
-                if (nodes != null) {
-                    foreach (var node in nodes) {
-                        if (node != null) {
-                            accounts.Add(WizCloudAccount.FromJson(node));
-                        }
-                    }
+        if (nodes != null) {
+            foreach (var node in nodes) {
+                if (node != null) {
+                    accounts.Add(WizCloudAccount.FromJson(node));
                 }
-
-                var pageInfo = jsonResponse["data"]?["cloudAccounts"]?["pageInfo"];
-                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
-                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
-
-                return (accounts, hasNextPage, endCursor);
             }
         }
+
+        var pageInfo = jsonResponse["data"]?["cloudAccounts"]?["pageInfo"];
+        bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+        string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+        return (accounts, hasNextPage, endCursor);
     }
 }

--- a/WizCloud/WizClient.Issues.cs
+++ b/WizCloud/WizClient.Issues.cs
@@ -101,47 +101,24 @@ public partial class WizClient {
                 projectId = projectFilter
             }
         };
-
         var requestBody = new { query, variables };
 
-        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Content = new StringContent(
-                JsonSerializer.Serialize(requestBody),
-                Encoding.UTF8,
-                "application/json"
-            );
+        var jsonResponse = await SendGraphQlRequestAsync(requestBody).ConfigureAwait(false);
 
-            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
-                if (!response.IsSuccessStatusCode) {
-                    var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var message = $"Request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase}).";
-                    if (!string.IsNullOrWhiteSpace(errorBody))
-                        message += $" Body: {errorBody}";
-                    throw new HttpRequestException(message);
-                }
+        var issues = new List<WizIssue>();
+        var nodes = jsonResponse["data"]?["issues"]?["nodes"]?.AsArray();
 
-                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var jsonResponse = JsonNode.Parse(content);
-
-                if (jsonResponse == null)
-                    throw new InvalidOperationException("Received null response from API");
-
-                var issues = new List<WizIssue>();
-                var nodes = jsonResponse["data"]?["issues"]?["nodes"]?.AsArray();
-
-                if (nodes != null) {
-                    foreach (var node in nodes) {
-                        if (node != null)
-                            issues.Add(WizIssue.FromJson(node));
-                    }
-                }
-
-                var pageInfo = jsonResponse["data"]?["issues"]?["pageInfo"];
-                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
-                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
-
-                return (issues, hasNextPage, endCursor);
+        if (nodes != null) {
+            foreach (var node in nodes) {
+                if (node != null)
+                    issues.Add(WizIssue.FromJson(node));
             }
         }
+
+        var pageInfo = jsonResponse["data"]?["issues"]?["pageInfo"];
+        bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+        string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+        return (issues, hasNextPage, endCursor);
     }
 }

--- a/WizCloud/WizClient.NetworkExposure.cs
+++ b/WizCloud/WizClient.NetworkExposure.cs
@@ -89,38 +89,21 @@ public partial class WizClient {
 
         var requestBody = new { query, variables };
 
-        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Content = new StringContent(JsonSerializer.Serialize(requestBody), Encoding.UTF8, "application/json");
+        var jsonResponse = await SendGraphQlRequestAsync(requestBody).ConfigureAwait(false);
 
-            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
-                if (!response.IsSuccessStatusCode) {
-                    var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var message = $"Request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase}).";
-                    if (!string.IsNullOrWhiteSpace(errorBody))
-                        message += $" Body: {errorBody}";
-                    throw new HttpRequestException(message);
-                }
-
-                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var jsonResponse = JsonNode.Parse(content);
-                if (jsonResponse == null)
-                    throw new InvalidOperationException("Received null response from API");
-
-                var exposures = new List<WizNetworkExposure>();
-                var nodes = jsonResponse["data"]?["networkExposure"]?["nodes"]?.AsArray();
-                if (nodes != null) {
-                    foreach (var node in nodes) {
-                        if (node != null)
-                            exposures.Add(WizNetworkExposure.FromJson(node));
-                    }
-                }
-
-                var pageInfo = jsonResponse["data"]?["networkExposure"]?["pageInfo"];
-                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
-                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
-
-                return (exposures, hasNextPage, endCursor);
+        var exposures = new List<WizNetworkExposure>();
+        var nodes = jsonResponse["data"]?["networkExposure"]?["nodes"]?.AsArray();
+        if (nodes != null) {
+            foreach (var node in nodes) {
+                if (node != null)
+                    exposures.Add(WizNetworkExposure.FromJson(node));
             }
         }
+
+        var pageInfo = jsonResponse["data"]?["networkExposure"]?["pageInfo"];
+        bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+        string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+        return (exposures, hasNextPage, endCursor);
     }
 }

--- a/WizCloud/WizClient.Resources.cs
+++ b/WizCloud/WizClient.Resources.cs
@@ -128,44 +128,22 @@ public partial class WizClient {
 
         var requestBody = new { query, variables };
 
-        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Content = new StringContent(
-                JsonSerializer.Serialize(requestBody),
-                Encoding.UTF8,
-                "application/json"
-            );
+        var jsonResponse = await SendGraphQlRequestAsync(requestBody).ConfigureAwait(false);
 
-            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
-                if (!response.IsSuccessStatusCode) {
-                    var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var message = $"Request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase}).";
-                    if (!string.IsNullOrWhiteSpace(errorBody))
-                        message += $" Body: {errorBody}";
-                    throw new HttpRequestException(message);
-                }
+        var resources = new List<WizResource>();
+        var nodes = jsonResponse["data"]?["resources"]?["nodes"]?.AsArray();
 
-                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var jsonResponse = JsonNode.Parse(content);
-
-                if (jsonResponse == null)
-                    throw new InvalidOperationException("Received null response from API");
-
-                var resources = new List<WizResource>();
-                var nodes = jsonResponse["data"]?["resources"]?["nodes"]?.AsArray();
-
-                if (nodes != null) {
-                    foreach (var node in nodes) {
-                        if (node != null)
-                            resources.Add(WizResource.FromJson(node));
-                    }
-                }
-
-                var pageInfo = jsonResponse["data"]?["resources"]?["pageInfo"];
-                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
-                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
-
-                return (resources, hasNextPage, endCursor);
+        if (nodes != null) {
+            foreach (var node in nodes) {
+                if (node != null)
+                    resources.Add(WizResource.FromJson(node));
             }
         }
+
+        var pageInfo = jsonResponse["data"]?["resources"]?["pageInfo"];
+        bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+        string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+        return (resources, hasNextPage, endCursor);
     }
 }

--- a/WizCloud/WizClient.Vulnerabilities.cs
+++ b/WizCloud/WizClient.Vulnerabilities.cs
@@ -109,47 +109,24 @@ public partial class WizClient {
                 projectId = projectFilter
             }
         };
-
         var requestBody = new { query, variables };
 
-        using (var request = new HttpRequestMessage(HttpMethod.Post, _apiEndpoint)) {
-            request.Content = new StringContent(
-                JsonSerializer.Serialize(requestBody),
-                Encoding.UTF8,
-                "application/json"
-            );
+        var jsonResponse = await SendGraphQlRequestAsync(requestBody).ConfigureAwait(false);
 
-            using (var response = await SendWithRefreshAsync(request).ConfigureAwait(false)) {
-                if (!response.IsSuccessStatusCode) {
-                    var errorBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    var message = $"Request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase}).";
-                    if (!string.IsNullOrWhiteSpace(errorBody))
-                        message += $" Body: {errorBody}";
-                    throw new HttpRequestException(message);
-                }
+        var vulnerabilities = new List<WizVulnerability>();
+        var nodes = jsonResponse["data"]?["vulnerabilities"]?["nodes"]?.AsArray();
 
-                var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                var jsonResponse = JsonNode.Parse(content);
-
-                if (jsonResponse == null)
-                    throw new InvalidOperationException("Received null response from API");
-
-                var vulnerabilities = new List<WizVulnerability>();
-                var nodes = jsonResponse["data"]?["vulnerabilities"]?["nodes"]?.AsArray();
-
-                if (nodes != null) {
-                    foreach (var node in nodes) {
-                        if (node != null)
-                            vulnerabilities.Add(WizVulnerability.FromJson(node));
-                    }
-                }
-
-                var pageInfo = jsonResponse["data"]?["vulnerabilities"]?["pageInfo"];
-                bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
-                string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
-
-                return (vulnerabilities, hasNextPage, endCursor);
+        if (nodes != null) {
+            foreach (var node in nodes) {
+                if (node != null)
+                    vulnerabilities.Add(WizVulnerability.FromJson(node));
             }
         }
+
+        var pageInfo = jsonResponse["data"]?["vulnerabilities"]?["pageInfo"];
+        bool hasNextPage = pageInfo?["hasNextPage"]?.GetValue<bool>() ?? false;
+        string? endCursor = pageInfo?["endCursor"]?.GetValue<string>();
+
+        return (vulnerabilities, hasNextPage, endCursor);
     }
 }


### PR DESCRIPTION
## Summary
- centralize GraphQL request serialization, sending and error handling in `SendGraphQlRequestAsync`
- simplify WizClient partials to use new helper
- update tests for centralized error message and helper usage

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6890badde4c8832e8e1697e5abd132ec