### PR TITLE
Enable pipeline input for Wiz cmdlets

### DIFF
--- a/Module/Examples/GetAuditLogs.ps1
+++ b/Module/Examples/GetAuditLogs.ps1
@@ -15,3 +15,6 @@ Write-Host "`nRetrieving audit logs..." -ForegroundColor Yellow
 $logs = Get-WizAuditLog -Verbose -MaxResults 50
 Write-Host "`nFound $($logs.Count) audit logs" -ForegroundColor Green
 $logs | Format-Table Timestamp, Action, Status
+
+# Example: Use pipeline to get audit logs for specific users
+Get-WizUser -MaxResults 1 | Get-WizAuditLog -MaxResults 10

--- a/Module/Examples/GetConfigurationFindings.ps1
+++ b/Module/Examples/GetConfigurationFindings.ps1
@@ -15,3 +15,6 @@ Write-Host "`nRetrieving configuration findings..." -ForegroundColor Yellow
 $findings = Get-WizConfigurationFinding -Verbose -MaxResults 50
 Write-Host "`nFound $($findings.Count) findings" -ForegroundColor Green
 $findings | Format-Table Id, Title, Severity
+
+# Example: Use pipeline to get configuration findings by project
+Get-WizProject | Get-WizConfigurationFinding -MaxResults 10

--- a/Module/Examples/GetIssues.ps1
+++ b/Module/Examples/GetIssues.ps1
@@ -15,3 +15,6 @@ Write-Host "`nRetrieving issues..." -ForegroundColor Yellow
 $issues = Get-WizIssue -Verbose -MaxResults 50
 Write-Host "`nFound $($issues.Count) issues" -ForegroundColor Green
 $issues | Format-Table Id, Name, Severity, Status
+
+# Example: Use pipeline to get issues by project
+Get-WizProject | Get-WizIssue -MaxResults 10

--- a/Module/Examples/GetNetworkExposure.ps1
+++ b/Module/Examples/GetNetworkExposure.ps1
@@ -15,3 +15,6 @@ Write-Host "`nRetrieving network exposure..." -ForegroundColor Yellow
 $exposures = Get-WizNetworkExposure -Verbose -MaxResults 50
 Write-Host "`nFound $($exposures.Count) exposures" -ForegroundColor Green
 $exposures | Format-Table Id, ExposureType, PublicIpAddress
+
+# Example: Use pipeline to get exposures by project
+Get-WizProject | Get-WizNetworkExposure -MaxResults 10

--- a/Module/Examples/GetResources.ps1
+++ b/Module/Examples/GetResources.ps1
@@ -15,3 +15,6 @@ Write-Host "`nRetrieving resources..." -ForegroundColor Yellow
 $resources = Get-WizResource -Verbose -MaxResults 50 -Type VM -CloudProvider AWS
 Write-Host "`nFound $($resources.Count) resources" -ForegroundColor Green
 $resources | Format-Table Id, Name, Type, CloudPlatform, Region
+
+# Example: Use pipeline to get resources by project
+Get-WizProject | Get-WizResource -MaxResults 10

--- a/Module/Examples/GetUsers.ps1
+++ b/Module/Examples/GetUsers.ps1
@@ -17,3 +17,6 @@ Write-Host "Found $($users.Count) users"
 $Users[1101] | Format-List
 
 $Users | Format-Table Name, UserPrincipalName, UserType, HasMfa, ProjectNames, Email, IsActive, CreatedAt, LastSeenAt, LastLoginAt, LastLoginIpAddress, ProductNames, ProductIds
+
+# Example 2: Get users for each project using the pipeline
+Get-WizProject | Get-WizUser -MaxResults 10

--- a/Module/Examples/GetVulnerabilities.ps1
+++ b/Module/Examples/GetVulnerabilities.ps1
@@ -16,3 +16,6 @@ $vulnerabilities = Get-WizVulnerability -Verbose -MaxResults 50
 Write-Host "`nFound $($vulnerabilities.Count) vulnerabilities" -ForegroundColor Green
 $vulnerabilities | Select-Object Id, Cve, @{Name='Cvss';Expression={$_.Cvss.Score}}, ExploitAvailable | Format-Table
 
+# Example: Use pipeline to get vulnerabilities by project
+Get-WizProject | Get-WizVulnerability -MaxResults 10
+

--- a/Module/Tests/Pipeline.Tests.ps1
+++ b/Module/Tests/Pipeline.Tests.ps1
@@ -1,0 +1,42 @@
+Describe 'Cmdlet pipeline metadata' {
+    BeforeAll {
+        $repoRoot = Resolve-Path -Path "$PSScriptRoot/../.."
+        Import-Module (Join-Path $repoRoot 'Module/WizCloud.psd1') -Force
+    }
+
+    It 'CmdletGetWizUser ProjectId accepts pipeline by property name' {
+        $attr = [WizCloud.PowerShell.CmdletGetWizUser].GetProperty('ProjectId').GetCustomAttributes([System.Management.Automation.ParameterAttribute], $false)[0]
+        $attr.ValueFromPipelineByPropertyName | Should -BeTrue
+    }
+
+    It 'CmdletGetWizResource ProjectId accepts pipeline by property name' {
+        $attr = [WizCloud.PowerShell.CmdletGetWizResource].GetProperty('ProjectId').GetCustomAttributes([System.Management.Automation.ParameterAttribute], $false)[0]
+        $attr.ValueFromPipelineByPropertyName | Should -BeTrue
+    }
+
+    It 'CmdletGetWizIssue ProjectId accepts pipeline by property name' {
+        $attr = [WizCloud.PowerShell.CmdletGetWizIssue].GetProperty('ProjectId').GetCustomAttributes([System.Management.Automation.ParameterAttribute], $false)[0]
+        $attr.ValueFromPipelineByPropertyName | Should -BeTrue
+    }
+
+    It 'CmdletGetWizNetworkExposure ProjectId accepts pipeline by property name' {
+        $attr = [WizCloud.PowerShell.CmdletGetWizNetworkExposure].GetProperty('ProjectId').GetCustomAttributes([System.Management.Automation.ParameterAttribute], $false)[0]
+        $attr.ValueFromPipelineByPropertyName | Should -BeTrue
+    }
+
+    It 'CmdletGetWizConfigurationFinding ProjectId accepts pipeline by property name' {
+        $attr = [WizCloud.PowerShell.CmdletGetWizConfigurationFinding].GetProperty('ProjectId').GetCustomAttributes([System.Management.Automation.ParameterAttribute], $false)[0]
+        $attr.ValueFromPipelineByPropertyName | Should -BeTrue
+    }
+
+    It 'CmdletGetWizVulnerability ProjectId accepts pipeline by property name' {
+        $attr = [WizCloud.PowerShell.CmdletGetWizVulnerability].GetProperty('ProjectId').GetCustomAttributes([System.Management.Automation.ParameterAttribute], $false)[0]
+        $attr.ValueFromPipelineByPropertyName | Should -BeTrue
+    }
+
+    It 'CmdletGetWizAuditLog User accepts pipeline by value and property name' {
+        $attr = [WizCloud.PowerShell.CmdletGetWizAuditLog].GetProperty('User').GetCustomAttributes([System.Management.Automation.ParameterAttribute], $false)[0]
+        $attr.ValueFromPipeline | Should -BeTrue
+        $attr.ValueFromPipelineByPropertyName | Should -BeTrue
+    }
+}

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizAuditLog.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizAuditLog.cs
@@ -27,7 +27,7 @@ public class CmdletGetWizAuditLog : AsyncPSCmdlet {
     [Parameter(Mandatory = false, HelpMessage = "Filter by end date.")]
     public DateTime? EndDate { get; set; }
 
-    [Parameter(Mandatory = false, HelpMessage = "Filter by user.")]
+    [Parameter(Mandatory = false, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by user.")]
     public string? User { get; set; }
 
     [Parameter(Mandatory = false, HelpMessage = "Filter by action.")]

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizConfigurationFinding.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizConfigurationFinding.cs
@@ -30,7 +30,7 @@ public class CmdletGetWizConfigurationFinding : AsyncPSCmdlet {
     [Parameter(Mandatory = false, HelpMessage = "Filter by category.")]
     public string[] Category { get; set; } = Array.Empty<string>();
 
-    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of findings to retrieve. Default is unlimited.")]

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizIssue.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizIssue.cs
@@ -31,7 +31,7 @@ public class CmdletGetWizIssue : AsyncPSCmdlet {
     [Parameter(Mandatory = false, HelpMessage = "Filter by issue status.")]
     public string[] Status { get; set; } = Array.Empty<string>();
 
-    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
     [Parameter(Mandatory = false, HelpMessage = "Filter by issue types.")]

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizNetworkExposure.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizNetworkExposure.cs
@@ -30,7 +30,7 @@ public class CmdletGetWizNetworkExposure : AsyncPSCmdlet {
     [Parameter(Mandatory = false, HelpMessage = "Filter by internet facing status.")]
     public bool? InternetFacing { get; set; }
 
-    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of exposures to retrieve. Default is unlimited.")]

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizResource.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizResource.cs
@@ -37,7 +37,7 @@ public class CmdletGetWizResource : AsyncPSCmdlet {
     [Parameter(Mandatory = false, HelpMessage = "Filter by tags.")]
     public Hashtable? Tag { get; set; }
 
-    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of resources to retrieve. Default is unlimited.")]

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
@@ -36,7 +36,7 @@ public class CmdletGetWizUser : AsyncPSCmdlet {
     [Parameter(Mandatory = false, HelpMessage = "Filter by Wiz user types.")]
     public WizUserType[] Type { get; set; } = Array.Empty<WizUserType>();
 
-    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
     /// <summary>

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizVulnerability.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizVulnerability.cs
@@ -30,7 +30,7 @@ public class CmdletGetWizVulnerability : AsyncPSCmdlet {
     [Parameter(Mandatory = false, HelpMessage = "Filter to vulnerabilities with an available exploit.")]
     public SwitchParameter ExploitAvailable { get; set; }
 
-    [Parameter(Mandatory = false, HelpMessage = "Filter by project identifier.")]
+    [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- allow project-scoped cmdlets to accept pipeline input via `ProjectId`
- enable `User` parameter in `Get-WizAuditLog` to accept pipeline values
- add examples and tests covering new pipeline behavior

## Testing
- `dotnet test`
- `pwsh -NoLogo -Command "Invoke-Pester -Script Module/Tests/Pipeline.Tests.ps1"`


------
https://chatgpt.com/codex/tasks/task_e_6890b9c2d6e0832eb586575114609428