### PR TITLE
Use JsonSerializer for audit log entry deserialization

### DIFF
--- a/WizCloud.Tests/WizAuditLogEntryTests.cs
+++ b/WizCloud.Tests/WizAuditLogEntryTests.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Text.Json.Nodes;
+using System.Text.Json;
 using WizCloud;
 
 namespace WizCloud.Tests;
@@ -7,7 +7,7 @@ namespace WizCloud.Tests;
 [TestClass]
 public sealed class WizAuditLogEntryTests {
     [TestMethod]
-    public void FromJson_ParsesFields() {
+    public void Deserialize_ParsesFields() {
         string jsonString = """
         {
             "id": "a1",
@@ -21,9 +21,9 @@ public sealed class WizAuditLogEntryTests {
             "details": "detail"
         }
         """;
-        JsonNode json = JsonNode.Parse(jsonString)!;
-        WizAuditLogEntry entry = WizAuditLogEntry.FromJson(json);
-        Assert.AreEqual("a1", entry.Id);
+        WizAuditLogEntry? entry = JsonSerializer.Deserialize<WizAuditLogEntry>(jsonString);
+        Assert.IsNotNull(entry);
+        Assert.AreEqual("a1", entry!.Id);
         Assert.IsNotNull(entry.User);
         Assert.AreEqual("LOGIN", entry.Action);
         Assert.IsNotNull(entry.Resource);

--- a/WizCloud/Models/WizAuditLogEntry.cs
+++ b/WizCloud/Models/WizAuditLogEntry.cs
@@ -1,129 +1,109 @@
 using System;
-using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 
 namespace WizCloud;
 
 /// <summary>
 /// Represents an audit log entry returned by the Wiz API.
 /// </summary>
-public class WizAuditLogEntry {
+public sealed class WizAuditLogEntry {
     /// <summary>
     /// Gets or sets the unique identifier of the audit log entry.
     /// </summary>
+    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the timestamp of the log entry.
     /// </summary>
+    [JsonPropertyName("timestamp")]
     public DateTime? Timestamp { get; set; }
 
     /// <summary>
     /// Gets or sets the user associated with the action.
     /// </summary>
+    [JsonPropertyName("user")]
     public WizAuditUser? User { get; set; }
 
     /// <summary>
     /// Gets or sets the action performed.
     /// </summary>
+    [JsonPropertyName("action")]
     public string? Action { get; set; }
 
     /// <summary>
     /// Gets or sets the resource affected by the action.
     /// </summary>
+    [JsonPropertyName("resource")]
     public WizAuditResource? Resource { get; set; }
 
     /// <summary>
     /// Gets or sets the status of the action.
     /// </summary>
+    [JsonPropertyName("status")]
     public string? Status { get; set; }
 
     /// <summary>
     /// Gets or sets the source IP address.
     /// </summary>
+    [JsonPropertyName("ipAddress")]
     public string? IpAddress { get; set; }
 
     /// <summary>
     /// Gets or sets the user agent string.
     /// </summary>
+    [JsonPropertyName("userAgent")]
     public string? UserAgent { get; set; }
 
     /// <summary>
     /// Gets or sets additional details about the action.
     /// </summary>
+    [JsonPropertyName("details")]
     public string? Details { get; set; }
-
-    /// <summary>
-    /// Creates a <see cref="WizAuditLogEntry"/> from JSON.
-    /// </summary>
-    public static WizAuditLogEntry FromJson(JsonNode node) {
-        var entry = new WizAuditLogEntry {
-            Id = node["id"]?.GetValue<string>() ?? string.Empty,
-            Timestamp = node["timestamp"]?.GetValue<DateTime?>()?.ToLocalTime(),
-            Action = node["action"]?.GetValue<string>(),
-            Status = node["status"]?.GetValue<string>(),
-            IpAddress = node["ipAddress"]?.GetValue<string>(),
-            UserAgent = node["userAgent"]?.GetValue<string>(),
-            Details = node["details"]?.GetValue<string>()
-        };
-
-        var user = node["user"];
-        if (user != null) {
-            entry.User = new WizAuditUser {
-                Id = user["id"]?.GetValue<string>() ?? string.Empty,
-                Name = user["name"]?.GetValue<string>() ?? string.Empty,
-                Email = user["email"]?.GetValue<string>() ?? string.Empty
-            };
-        }
-
-        var resource = node["resource"];
-        if (resource != null) {
-            entry.Resource = new WizAuditResource {
-                Type = resource["type"]?.GetValue<string>() ?? string.Empty,
-                Id = resource["id"]?.GetValue<string>() ?? string.Empty,
-                Name = resource["name"]?.GetValue<string>() ?? string.Empty
-            };
-        }
-
-        return entry;
-    }
 }
 
 /// <summary>
 /// Represents a user in an audit log entry.
 /// </summary>
-public class WizAuditUser {
+public sealed class WizAuditUser {
     /// <summary>
     /// Gets or sets the user identifier.
     /// </summary>
+    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the user name.
     /// </summary>
+    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the user email.
     /// </summary>
+    [JsonPropertyName("email")]
     public string Email { get; set; } = string.Empty;
 }
 
 /// <summary>
 /// Represents a resource referenced in an audit log entry.
 /// </summary>
-public class WizAuditResource {
+public sealed class WizAuditResource {
     /// <summary>
     /// Gets or sets the resource type.
     /// </summary>
+    [JsonPropertyName("type")]
     public string Type { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the resource identifier.
     /// </summary>
+    [JsonPropertyName("id")]
     public string Id { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the resource name.
     /// </summary>
+    [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 }

--- a/WizCloud/WizClient.AuditLogs.cs
+++ b/WizCloud/WizClient.AuditLogs.cs
@@ -92,9 +92,12 @@ public partial class WizClient {
         var logs = new List<WizAuditLogEntry>();
         var nodes = jsonResponse["data"]?["auditLogs"]?["nodes"]?.AsArray();
         if (nodes != null) {
-            foreach (var node in nodes) {
-                if (node != null)
-                    logs.Add(WizAuditLogEntry.FromJson(node));
+            foreach (JsonNode? node in nodes) {
+                if (node != null) {
+                    var log = node.Deserialize<WizAuditLogEntry>();
+                    if (log != null)
+                        logs.Add(log);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- convert `WizAuditLogEntry` and nested types into DTOs with `JsonPropertyName` attributes
- deserialize audit log nodes directly in client code
- update unit test to verify `JsonSerializer` deserialization

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6890d1b6a2d8832eb20b0689b6fbf314