### PR TITLE
Add user count query and method

### DIFF
--- a/WizCloud.Tests/GetUsersCountAsyncTests.cs
+++ b/WizCloud.Tests/GetUsersCountAsyncTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Reflection;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class GetUsersCountAsyncTests {
+    private sealed class FakeHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _response;
+
+        public FakeHandler(string content) {
+            _response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(content) };
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            return Task.FromResult(_response);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetUsersCountAsync_ReturnsParsedCount() {
+        var handler = new FakeHandler("{\"data\":{\"cloudResourcesV2\":{\"totalCount\":5}}}");
+        var field = typeof(WizClient).GetField("_httpClient", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.IsNotNull(field);
+        var original = (HttpClient)field!.GetValue(null)!;
+        try {
+            field.SetValue(null, new HttpClient(handler));
+            using var client = new WizClient("token");
+            var count = await client.GetUsersCountAsync();
+            Assert.AreEqual(5, count);
+        } finally {
+            field.SetValue(null, original);
+        }
+    }
+}

--- a/WizCloud/GraphQlQueries.cs
+++ b/WizCloud/GraphQlQueries.cs
@@ -24,6 +24,15 @@ public static class GraphQlQueries {
                 mediumSeverityCount highSeverityCount criticalSeverityCount
             }
         }";
+    /// <summary>
+    /// Query for retrieving the total count of cloud identity principals.
+    /// </summary>
+    public const string UsersCountQuery = @"query CloudIdentityPrincipalsCount($filterBy: CloudResourceV2Filters) {
+            cloudResourcesV2(filterBy: $filterBy) {
+                totalCount
+            }
+        }";
+
 
     /// <summary>
     /// Query for retrieving projects.

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -17,7 +17,7 @@ namespace WizCloud;
 /// Provides a client for interacting with the Wiz GraphQL API.
 /// </summary>
 public partial class WizClient : IDisposable {
-    private static readonly HttpClient _httpClient = CreateClient();
+    private static HttpClient _httpClient = CreateClient();
     private readonly string _apiEndpoint;
     private readonly string? _clientId;
     private readonly string? _clientSecret;


### PR DESCRIPTION
## Summary
- add UsersCountQuery to fetch total count of principals
- expose GetUsersCountAsync to return user totals
- validate GetUsersCountAsync parses totalCount via unit test

## Testing
- `dotnet build WizCloud/WizCloud.csproj -f netstandard2.0`
- `dotnet build WizCloud/WizCloud.csproj -f net472`
- `dotnet build WizCloud/WizCloud.csproj -f net8.0`
- `dotnet test WizCloud.Tests/WizCloud.Tests.csproj --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_689457f38504832eae26514774c6090b