### PR TITLE
Fix user type filter and add tests

### DIFF
--- a/WizCloud.Tests/GetUsersAsyncTypeFilterTests.cs
+++ b/WizCloud.Tests/GetUsersAsyncTypeFilterTests.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class GetUsersAsyncTypeFilterTests {
+    private sealed class InspectingHandler : HttpMessageHandler {
+        private readonly HttpResponseMessage _response;
+        public string? LastRequestBody { get; private set; }
+
+        public InspectingHandler(string responseContent) {
+            _response = new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent(responseContent)
+            };
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            LastRequestBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            return _response;
+        }
+    }
+
+    [TestMethod]
+    public async Task GetUsersAsync_SendsTypeFilterAndReturnsUsers() {
+        var responseJson = "{\"data\":{\"cloudResourcesV2\":{\"pageInfo\":{\"hasNextPage\":false},\"nodes\":[{\"id\":\"1\",\"name\":\"A\",\"type\":\"USER_ACCOUNT\"},{\"id\":\"2\",\"name\":\"B\",\"type\":\"SERVICE_ACCOUNT\"}]}}}";
+        var handler = new InspectingHandler(responseJson);
+        var field = typeof(WizClient).GetField("_httpClient", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.IsNotNull(field);
+        var original = (HttpClient)field!.GetValue(null)!;
+        try {
+            field.SetValue(null, new HttpClient(handler));
+            using var client = new WizClient("token");
+            var users = await client.GetUsersAsync(10, new[] { WizUserType.USER_ACCOUNT, WizUserType.SERVICE_ACCOUNT });
+            Assert.AreEqual(2, users.Count);
+            CollectionAssert.AreEquivalent(
+                new[] { WizUserType.USER_ACCOUNT, WizUserType.SERVICE_ACCOUNT },
+                users.Select(u => u.Type).ToArray());
+            var json = JsonNode.Parse(handler.LastRequestBody!)!;
+            var types = json["variables"]?["filterBy"]?["type"]?["equalsAnyOf"]?.AsArray().Select(n => n!.GetValue<string>()).ToArray();
+            CollectionAssert.AreEquivalent(new[] { "USER_ACCOUNT", "SERVICE_ACCOUNT" }, types);
+        } finally {
+            field.SetValue(null, original);
+        }
+    }
+}

--- a/WizCloud/WizClient.Users.cs
+++ b/WizCloud/WizClient.Users.cs
@@ -58,7 +58,7 @@ public partial class WizClient {
 
         var variables = new {
             filterBy = new {
-                type = new { equals = typeFilter },
+                type = new { equalsAnyOf = typeFilter },
                 property = propertyFilter
             }
         };
@@ -163,7 +163,7 @@ public partial class WizClient {
             first,
             after,
             filterBy = new {
-                type = new { equals = typeFilter },
+                type = new { equalsAnyOf = typeFilter },
                 property = propertyFilter
             }
         };


### PR DESCRIPTION
## Summary
- adjust GraphQL user type filter to use `equalsAnyOf`
- add unit test to verify filter and returned types
- extend PowerShell tests to check `-Type` restriction

## Testing
- `dotnet build`
- `dotnet test`
- `pwsh -NoLogo -NoProfile -File Module/WizCloud.Tests.ps1` *(fails: ParameterBindingException: A parameter cannot be found that matches parameter name 'MemberName')*


------
https://chatgpt.com/codex/tasks/task_e_68945fbc40f0832eb156d9c54abfe2c3