### PR TITLE
feat: add parallel user retrieval

### DIFF
--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
@@ -141,7 +141,7 @@ public class CmdletGetWizUser : AsyncPSCmdlet {
                 ? Math.Min(MaxResults.Value, totalUsers.Value)
                 : MaxResults;
 
-            await foreach (var user in _wizClient.GetUsersAsyncEnumerable(PageSize, Type, ProjectId, CancelToken)) {
+            await foreach (var user in _wizClient.GetUsersAsyncEnumerable(PageSize, Type, ProjectId, 1, CancelToken)) {
                 if (CancelToken.IsCancellationRequested)
                     break;
 

--- a/WizCloud.Tests/GetUsersParallelTests.cs
+++ b/WizCloud.Tests/GetUsersParallelTests.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class GetUsersParallelTests {
+    private sealed class PagingHandler : HttpMessageHandler {
+        private int _callCount;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            _callCount++;
+            string content = _callCount switch {
+                1 => "{\"data\":{\"cloudResourcesV2\":{\"pageInfo\":{\"hasNextPage\":true,\"endCursor\":\"c1\"},\"nodes\":[{\"id\":\"1\",\"name\":\"A\",\"type\":\"USER_ACCOUNT\"},{\"id\":\"2\",\"name\":\"B\",\"type\":\"USER_ACCOUNT\"}]}}}",
+                2 => "{\"data\":{\"cloudResourcesV2\":{\"pageInfo\":{\"hasNextPage\":false},\"nodes\":[{\"id\":\"3\",\"name\":\"C\",\"type\":\"USER_ACCOUNT\"},{\"id\":\"4\",\"name\":\"D\",\"type\":\"USER_ACCOUNT\"}]}}}",
+                _ => "{\"data\":{\"cloudResourcesV2\":{\"pageInfo\":{\"hasNextPage\":false},\"nodes\":[]}}}"
+            };
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(content) });
+        }
+    }
+
+    [TestMethod]
+    public async Task GetAllUsersAsync_ReturnsAllPages() {
+        var handler = new PagingHandler();
+        var field = typeof(WizClient).GetField("_httpClient", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.IsNotNull(field);
+        var original = (HttpClient)field!.GetValue(null)!;
+        try {
+            field.SetValue(null, new HttpClient(handler));
+            using var client = new WizClient("token");
+            var users = await client.GetAllUsersAsync(pageSize: 2, degreeOfParallelism: 2);
+            Assert.AreEqual(4, users.Count);
+            CollectionAssert.AreEqual(new[] { "1", "2", "3", "4" }, users.Select(u => u.Id).ToArray());
+        } finally {
+            field.SetValue(null, original);
+        }
+    }
+
+    [TestMethod]
+    public async Task GetUsersAsyncEnumerable_ReturnsAllPages() {
+        var handler = new PagingHandler();
+        var field = typeof(WizClient).GetField("_httpClient", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.IsNotNull(field);
+        var original = (HttpClient)field!.GetValue(null)!;
+        try {
+            field.SetValue(null, new HttpClient(handler));
+            using var client = new WizClient("token");
+            var list = new List<WizUser>();
+            await foreach (var user in client.GetUsersAsyncEnumerable(2, null, null, 2)) {
+                list.Add(user);
+            }
+            Assert.AreEqual(4, list.Count);
+            CollectionAssert.AreEqual(new[] { "1", "2", "3", "4" }, list.Select(u => u.Id).ToArray());
+        } finally {
+            field.SetValue(null, original);
+        }
+    }
+}

--- a/WizCloud/WizCloud.csproj
+++ b/WizCloud/WizCloud.csproj
@@ -19,6 +19,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="*" />
+    <PackageReference Include="System.Threading.Channels" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
## Summary
- add degreeOfParallelism to user retrieval APIs
- prefetch user pages via bounded channel for deterministic streaming
- cover concurrent enumeration with tests and update PowerShell cmdlet

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68946552061c832e822728b9c904a22b