### PR TITLE
Add configurable HTTP retry logic to WizClient

### DIFF
--- a/WizCloud.Examples/Samples/ClientCredentialSample.cs
+++ b/WizCloud.Examples/Samples/ClientCredentialSample.cs
@@ -5,7 +5,7 @@ using WizCloud;
 namespace WizCloud.Examples;
 internal static class ClientCredentialSample {
     public static async Task RunAsync() {
-        using var client = await WizClient.CreateAsync("clientId", "clientSecret");
+        using var client = await WizClient.CreateAsync("clientId", "clientSecret", retryCount: 5, retryDelay: TimeSpan.FromSeconds(2));
         var users = await client.GetUsersAsync(pageSize: 1);
         Console.WriteLine($"Client credentials sample retrieved {users.Count} user(s).");
         if (users.Count > 0) {

--- a/WizCloud.Tests/WizClientFactoryTests.cs
+++ b/WizCloud.Tests/WizClientFactoryTests.cs
@@ -11,7 +11,7 @@ public sealed class WizClientFactoryTests {
     public void CreateAsync_ReturnsTaskOfWizClient() {
         var method = typeof(WizClient).GetMethod(
             "CreateAsync",
-            new[] { typeof(string), typeof(string), typeof(WizRegion) });
+            new[] { typeof(string), typeof(string), typeof(WizRegion), typeof(int), typeof(TimeSpan?) });
         Assert.IsNotNull(method);
         Assert.AreEqual(typeof(Task<WizClient>), method!.ReturnType);
     }

--- a/WizCloud.Tests/WizClientRetryTests.cs
+++ b/WizCloud.Tests/WizClientRetryTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WizCloud.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class WizClientRetryTests {
+    private sealed class TransientStatusHandler : HttpMessageHandler {
+        private readonly int _failures;
+        public int CallCount { get; private set; }
+
+        public TransientStatusHandler(int failures) => _failures = failures;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            CallCount++;
+            if (CallCount <= _failures)
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("{\"data\":{}}")
+            });
+        }
+    }
+
+    private sealed class ExceptionHandler : HttpMessageHandler {
+        public int CallCount { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            CallCount++;
+            throw new HttpRequestException("fail");
+        }
+    }
+
+    [TestMethod]
+    public async Task SendGraphQlRequestAsync_RetriesOnTransientStatusAndSucceeds() {
+        var handler = new TransientStatusHandler(2);
+        var field = typeof(WizClient).GetField("_httpClient", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var original = (HttpClient)field.GetValue(null)!;
+        try {
+            field.SetValue(null, new HttpClient(handler));
+            using var client = new WizClient("token", retryCount: 2, retryDelay: TimeSpan.FromMilliseconds(1));
+            var method = typeof(WizClient).GetMethod("SendGraphQlRequestAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var task = (Task<JsonNode>)method.Invoke(client, new object[] { new { query = "" } })!;
+            var result = await task.ConfigureAwait(false);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(3, handler.CallCount);
+        } finally {
+            field.SetValue(null, original);
+        }
+    }
+
+    [TestMethod]
+    public async Task SendGraphQlRequestAsync_RetriesAndThrowsAfterMaxAttempts() {
+        var handler = new ExceptionHandler();
+        var field = typeof(WizClient).GetField("_httpClient", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var original = (HttpClient)field.GetValue(null)!;
+        try {
+            field.SetValue(null, new HttpClient(handler));
+            using var client = new WizClient("token", retryCount: 2, retryDelay: TimeSpan.FromMilliseconds(1));
+            var method = typeof(WizClient).GetMethod("SendGraphQlRequestAsync", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(async () => {
+                var task = (Task<JsonNode>)method.Invoke(client, new object[] { new { query = "" } })!;
+                await task.ConfigureAwait(false);
+            }).ConfigureAwait(false);
+            Assert.AreEqual(3, handler.CallCount);
+        } finally {
+            field.SetValue(null, original);
+        }
+    }
+}

--- a/WizCloud/WizClient.cs
+++ b/WizCloud/WizClient.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Net;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Linq;
@@ -22,6 +23,8 @@ public partial class WizClient : IDisposable {
     private readonly string? _clientId;
     private readonly string? _clientSecret;
     private readonly WizRegion _region;
+    private readonly int _retryCount;
+    private readonly TimeSpan _retryDelay;
     private string _token;
     private bool _disposed;
 
@@ -38,8 +41,10 @@ public partial class WizClient : IDisposable {
     /// <param name="region">The Wiz region enumeration value. Defaults to <see cref="WizRegion.EU17"/>.</param>
     /// <param name="clientId">Optional Wiz service account client ID used for token refresh.</param>
     /// <param name="clientSecret">Optional Wiz service account client secret used for token refresh.</param>
+    /// <param name="retryCount">Number of times to retry transient failures.</param>
+    /// <param name="retryDelay">Initial delay between retries. Defaults to 1 second.</param>
     /// <exception cref="ArgumentException">Thrown when the token is null or empty.</exception>
-    public WizClient(string token, WizRegion region = WizRegion.EU17, string? clientId = null, string? clientSecret = null) {
+    public WizClient(string token, WizRegion region = WizRegion.EU17, string? clientId = null, string? clientSecret = null, int retryCount = 3, TimeSpan? retryDelay = null) {
         if (string.IsNullOrWhiteSpace(token))
             throw new ArgumentException("Token cannot be null or empty", nameof(token));
 
@@ -47,6 +52,8 @@ public partial class WizClient : IDisposable {
         _clientId = clientId;
         _clientSecret = clientSecret;
         _region = region;
+        _retryCount = retryCount;
+        _retryDelay = retryDelay ?? TimeSpan.FromSeconds(1);
         var regionString = WizRegionHelper.ToApiString(region);
         _apiEndpoint = $"https://api.{regionString}.app.wiz.io/graphql";
     }
@@ -57,22 +64,26 @@ public partial class WizClient : IDisposable {
     /// <param name="clientId">The Wiz service account client ID.</param>
     /// <param name="clientSecret">The Wiz service account client secret.</param>
     /// <param name="region">The Wiz region enumeration value.</param>
+    /// <param name="retryCount">Number of times to retry transient failures.</param>
+    /// <param name="retryDelay">Initial delay between retries. Defaults to 1 second.</param>
     /// <returns>A <see cref="WizClient"/> instance authenticated with the retrieved token.</returns>
-    public static async Task<WizClient> CreateAsync(string clientId, string clientSecret, WizRegion region = WizRegion.EU17) {
+    public static async Task<WizClient> CreateAsync(string clientId, string clientSecret, WizRegion region = WizRegion.EU17, int retryCount = 3, TimeSpan? retryDelay = null) {
         var token = await WizAuthentication.AcquireTokenAsync(clientId, clientSecret, region).ConfigureAwait(false);
-        return new WizClient(token, region, clientId, clientSecret);
+        return new WizClient(token, region, clientId, clientSecret, retryCount, retryDelay);
     }
 
     /// <inheritdoc cref="CreateAsync(string, string, WizRegion)"/>
     /// <param name="clientId">The Wiz service account client ID.</param>
     /// <param name="clientSecret">The Wiz service account client secret.</param>
     /// <param name="region">The Wiz region identifier.</param>
-    public static Task<WizClient> CreateAsync(string clientId, string clientSecret, string region)
-        => CreateAsync(clientId, clientSecret, WizRegionHelper.FromString(region));
+    /// <param name="retryCount">Number of times to retry transient failures.</param>
+    /// <param name="retryDelay">Initial delay between retries. Defaults to 1 second.</param>
+    public static Task<WizClient> CreateAsync(string clientId, string clientSecret, string region, int retryCount = 3, TimeSpan? retryDelay = null)
+        => CreateAsync(clientId, clientSecret, WizRegionHelper.FromString(region), retryCount, retryDelay);
 
     private async Task<HttpResponseMessage> SendWithRefreshAsync(HttpRequestMessage request) {
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
-        var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+        var response = await SendAsyncWithRetry(request).ConfigureAwait(false);
 
         if (response.StatusCode == HttpStatusCode.Unauthorized &&
             !string.IsNullOrEmpty(_clientId) &&
@@ -80,10 +91,55 @@ public partial class WizClient : IDisposable {
             response.Dispose();
             _token = await WizAuthentication.AcquireTokenAsync(_clientId!, _clientSecret!, _region).ConfigureAwait(false);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
-            response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+            response = await SendAsyncWithRetry(request).ConfigureAwait(false);
         }
 
         return response;
+    }
+
+    private async Task<HttpResponseMessage> SendAsyncWithRetry(HttpRequestMessage request) {
+        var delay = _retryDelay;
+        for (var attempt = 0; ; attempt++) {
+            using var clone = await CloneRequestAsync(request).ConfigureAwait(false);
+            try {
+                var response = await _httpClient.SendAsync(clone).ConfigureAwait(false);
+                if (IsTransient(response.StatusCode) && attempt < _retryCount) {
+                    response.Dispose();
+                    await Task.Delay(delay).ConfigureAwait(false);
+                    delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 2);
+                    continue;
+                }
+
+                return response;
+            } catch (HttpRequestException) when (attempt < _retryCount) {
+                await Task.Delay(delay).ConfigureAwait(false);
+                delay = TimeSpan.FromMilliseconds(delay.TotalMilliseconds * 2);
+            }
+        }
+    }
+
+    private static bool IsTransient(HttpStatusCode statusCode)
+        => (int)statusCode >= 500 ||
+           statusCode == HttpStatusCode.RequestTimeout ||
+           statusCode == (HttpStatusCode)429;
+
+    private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage request) {
+        var clone = new HttpRequestMessage(request.Method, request.RequestUri) { Version = request.Version };
+
+        foreach (var header in request.Headers)
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+        if (request.Content != null) {
+            var ms = new MemoryStream();
+            await request.Content.CopyToAsync(ms).ConfigureAwait(false);
+            ms.Position = 0;
+            var content = new StreamContent(ms);
+            foreach (var header in request.Content.Headers)
+                content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            clone.Content = content;
+        }
+
+        return clone;
     }
 
     private async Task<JsonNode> SendGraphQlRequestAsync(object requestBody) {


### PR DESCRIPTION
## Summary
- add configurable retry count and delay to `WizClient` and factory methods
- implement exponential backoff and transient error handling around HTTP requests
- add unit tests for successful and failing retry scenarios
- update sample to show custom retry parameters

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68946a844680832e8b9400daba766e0f