### PR TITLE
Document cmdlet parameters and WizClient methods

### DIFF
--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizAuditLog.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizAuditLog.cs
@@ -21,21 +21,39 @@ public class CmdletGetWizAuditLog : AsyncPSCmdlet {
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
 
+    /// <summary>
+    /// <para type="description">Filter audit logs by start date.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by start date.")]
     public DateTime? StartDate { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter audit logs by end date.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by end date.")]
     public DateTime? EndDate { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter audit logs by user.</para>
+    /// </summary>
     [Parameter(Mandatory = false, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by user.")]
     public string? User { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter audit logs by action.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by action.")]
     public string? Action { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter audit logs by status.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by status.")]
     public string? Status { get; set; }
 
+    /// <summary>
+    /// <para type="description">Maximum number of audit logs to retrieve. Default is unlimited.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of audit logs to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
@@ -43,6 +61,9 @@ public class CmdletGetWizAuditLog : AsyncPSCmdlet {
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
 
+    /// <summary>
+    /// <para type="description">Initializes the Wiz client for audit log retrieval.</para>
+    /// </summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -83,6 +104,9 @@ public class CmdletGetWizAuditLog : AsyncPSCmdlet {
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// <para type="description">Processes the Get-WizAuditLog command.</para>
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -142,6 +166,9 @@ public class CmdletGetWizAuditLog : AsyncPSCmdlet {
         }
     }
 
+    /// <summary>
+    /// <para type="description">Releases the Wiz client resources.</para>
+    /// </summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizCompliance.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizCompliance.cs
@@ -14,15 +14,24 @@ namespace WizCloud.PowerShell;
 [Cmdlet(VerbsCommon.Get, "WizCompliance")]
 [OutputType(typeof(WizComplianceResult))]
 public class CmdletGetWizCompliance : AsyncPSCmdlet {
+    /// <summary>
+    /// <para type="description">Filter compliance results by framework.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by compliance framework.")]
     public string[] Framework { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// <para type="description">Filter results by minimum compliance score.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by minimum compliance score.")]
     public double? MinScore { get; set; }
 
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
 
+    /// <summary>
+    /// <para type="description">Initializes the Wiz client for compliance retrieval.</para>
+    /// </summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -63,6 +72,9 @@ public class CmdletGetWizCompliance : AsyncPSCmdlet {
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// <para type="description">Processes the Get-WizCompliance command.</para>
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -111,6 +123,9 @@ public class CmdletGetWizCompliance : AsyncPSCmdlet {
         }
     }
 
+    /// <summary>
+    /// <para type="description">Releases the Wiz client resources.</para>
+    /// </summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizConfigurationFinding.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizConfigurationFinding.cs
@@ -21,18 +21,33 @@ public class CmdletGetWizConfigurationFinding : AsyncPSCmdlet {
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
 
+    /// <summary>
+    /// <para type="description">Filter configuration findings by compliance framework.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by compliance framework.")]
     public string[] Framework { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// <para type="description">Filter findings by severity.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by severity.")]
     public WizSeverity[] Severity { get; set; } = Array.Empty<WizSeverity>();
 
+    /// <summary>
+    /// <para type="description">Filter findings by category.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by category.")]
     public string[] Category { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// <para type="description">Filter findings by project identifier.</para>
+    /// </summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
+    /// <summary>
+    /// <para type="description">Maximum number of findings to retrieve. Default is unlimited.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of findings to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
@@ -40,6 +55,9 @@ public class CmdletGetWizConfigurationFinding : AsyncPSCmdlet {
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
 
+    /// <summary>
+    /// <para type="description">Initializes the Wiz client for configuration findings.</para>
+    /// </summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -80,6 +98,9 @@ public class CmdletGetWizConfigurationFinding : AsyncPSCmdlet {
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// <para type="description">Processes the Get-WizConfigurationFinding command.</para>
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -139,6 +160,9 @@ public class CmdletGetWizConfigurationFinding : AsyncPSCmdlet {
         }
     }
 
+    /// <summary>
+    /// <para type="description">Releases the Wiz client resources.</para>
+    /// </summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizIssue.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizIssue.cs
@@ -25,15 +25,27 @@ public class CmdletGetWizIssue : AsyncPSCmdlet {
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
 
+    /// <summary>
+    /// <para type="description">Filter issues by severity.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by issue severities.")]
     public WizSeverity[] Severity { get; set; } = Array.Empty<WizSeverity>();
 
+    /// <summary>
+    /// <para type="description">Filter issues by status.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by issue status.")]
     public string[] Status { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// <para type="description">Filter issues by project identifier.</para>
+    /// </summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter issues by type.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by issue types.")]
     public string[] Type { get; set; } = Array.Empty<string>();
 

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizNetworkExposure.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizNetworkExposure.cs
@@ -21,18 +21,33 @@ public class CmdletGetWizNetworkExposure : AsyncPSCmdlet {
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
 
+    /// <summary>
+    /// <para type="description">Filter exposures by port.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by port.")]
     public int[] Port { get; set; } = Array.Empty<int>();
 
+    /// <summary>
+    /// <para type="description">Filter exposures by protocol.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by protocol.")]
     public string[] Protocol { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// <para type="description">Filter exposures by internet-facing status.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by internet facing status.")]
     public bool? InternetFacing { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter exposures by project identifier.</para>
+    /// </summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
+    /// <summary>
+    /// <para type="description">Maximum number of exposures to retrieve. Default is unlimited.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of exposures to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
@@ -40,6 +55,9 @@ public class CmdletGetWizNetworkExposure : AsyncPSCmdlet {
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
 
+    /// <summary>
+    /// <para type="description">Initializes the Wiz client for network exposure retrieval.</para>
+    /// </summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -80,6 +98,9 @@ public class CmdletGetWizNetworkExposure : AsyncPSCmdlet {
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// <para type="description">Processes the Get-WizNetworkExposure command.</para>
+    /// </summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -139,6 +160,9 @@ public class CmdletGetWizNetworkExposure : AsyncPSCmdlet {
         }
     }
 
+    /// <summary>
+    /// <para type="description">Releases the Wiz client resources.</para>
+    /// </summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizResource.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizResource.cs
@@ -22,24 +22,45 @@ public class CmdletGetWizResource : AsyncPSCmdlet {
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
 
+    /// <summary>
+    /// <para type="description">Filter resources by type.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by resource type.")]
     public string[] Type { get; set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// <para type="description">Filter resources by cloud provider.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by cloud provider.")]
     public WizCloudProvider[] CloudProvider { get; set; } = Array.Empty<WizCloudProvider>();
 
+    /// <summary>
+    /// <para type="description">Filter resources by region.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by resource region.")]
     public string? Region { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter resources by public accessibility.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by public accessibility.")]
     public SwitchParameter PubliclyAccessible { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter resources by tag.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by tags.")]
     public Hashtable? Tag { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter resources by project identifier.</para>
+    /// </summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
+    /// <summary>
+    /// <para type="description">Maximum number of resources to retrieve. Default is unlimited.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of resources to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
@@ -48,7 +69,7 @@ public class CmdletGetWizResource : AsyncPSCmdlet {
     private int _retrievedCount = 0;
 
     /// <summary>
-    /// Initialize the Wiz client.
+    /// <para type="description">Initializes the Wiz client for resource retrieval.</para>
     /// </summary>
     protected override Task BeginProcessingAsync() {
         try {
@@ -90,7 +111,7 @@ public class CmdletGetWizResource : AsyncPSCmdlet {
     }
 
     /// <summary>
-    /// Retrieve and output Wiz resources.
+    /// <para type="description">Processes the Get-WizResource command.</para>
     /// </summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
@@ -168,7 +189,7 @@ public class CmdletGetWizResource : AsyncPSCmdlet {
     }
 
     /// <summary>
-    /// Clean up resources.
+    /// <para type="description">Releases the Wiz client resources.</para>
     /// </summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
@@ -37,9 +37,15 @@ public class CmdletGetWizUser : AsyncPSCmdlet {
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
 
+    /// <summary>
+    /// <para type="description">Filter users by Wiz user type.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by Wiz user types.")]
     public WizUserType[] Type { get; set; } = Array.Empty<WizUserType>();
 
+    /// <summary>
+    /// <para type="description">Filter users by project identifier.</para>
+    /// </summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizVulnerability.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizVulnerability.cs
@@ -21,15 +21,27 @@ public class CmdletGetWizVulnerability : AsyncPSCmdlet {
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
 
+    /// <summary>
+    /// <para type="description">Filter vulnerabilities by CVE identifier.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by CVE identifier.")]
     public string? CVE { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter vulnerabilities by minimum CVSS score.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by minimum CVSS score.")]
     public double? MinCVSS { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter to vulnerabilities with an available exploit.</para>
+    /// </summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter to vulnerabilities with an available exploit.")]
     public SwitchParameter ExploitAvailable { get; set; }
 
+    /// <summary>
+    /// <para type="description">Filter vulnerabilities by project identifier.</para>
+    /// </summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
 
@@ -44,7 +56,7 @@ public class CmdletGetWizVulnerability : AsyncPSCmdlet {
     private int _retrievedCount = 0;
 
     /// <summary>
-    /// Initialize the Wiz client.
+    /// <para type="description">Initializes the Wiz client for vulnerability retrieval.</para>
     /// </summary>
     protected override Task BeginProcessingAsync() {
         try {
@@ -87,7 +99,7 @@ public class CmdletGetWizVulnerability : AsyncPSCmdlet {
     }
 
     /// <summary>
-    /// Retrieve and output Wiz vulnerabilities.
+    /// <para type="description">Processes the Get-WizVulnerability command.</para>
     /// </summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
@@ -155,7 +167,7 @@ public class CmdletGetWizVulnerability : AsyncPSCmdlet {
     }
 
     /// <summary>
-    /// Clean up resources.
+    /// <para type="description">Releases the Wiz client resources.</para>
     /// </summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();

--- a/WizCloud/WizClient.AuditLogs.cs
+++ b/WizCloud/WizClient.AuditLogs.cs
@@ -12,6 +12,16 @@ using System.Threading.Tasks;
 namespace WizCloud;
 
 public partial class WizClient {
+    /// <summary>
+    /// Retrieves audit logs from Wiz.
+    /// </summary>
+    /// <param name="pageSize">The number of audit logs to retrieve per page.</param>
+    /// <param name="startDate">Optional start date filter.</param>
+    /// <param name="endDate">Optional end date filter.</param>
+    /// <param name="user">Optional user filter.</param>
+    /// <param name="action">Optional action filter.</param>
+    /// <param name="status">Optional status filter.</param>
+    /// <returns>A list of audit log entries.</returns>
     public async Task<List<WizAuditLogEntry>> GetAuditLogsAsync(
         int pageSize = 20,
         DateTime? startDate = null,
@@ -33,6 +43,17 @@ public partial class WizClient {
         return logs;
     }
 
+    /// <summary>
+    /// Streams audit logs from Wiz as an asynchronous sequence.
+    /// </summary>
+    /// <param name="pageSize">The number of audit logs to retrieve per page.</param>
+    /// <param name="startDate">Optional start date filter.</param>
+    /// <param name="endDate">Optional end date filter.</param>
+    /// <param name="user">Optional user filter.</param>
+    /// <param name="action">Optional action filter.</param>
+    /// <param name="status">Optional status filter.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>An async enumerable of audit log entries.</returns>
     public async IAsyncEnumerable<WizAuditLogEntry> GetAuditLogsAsyncEnumerable(
         int pageSize = 20,
         DateTime? startDate = null,
@@ -64,6 +85,17 @@ public partial class WizClient {
         }
     }
 
+    /// <summary>
+    /// Retrieves a single page of audit logs from the Wiz API.
+    /// </summary>
+    /// <param name="first">The number of audit logs to retrieve.</param>
+    /// <param name="after">Cursor for pagination.</param>
+    /// <param name="startDate">Optional start date filter.</param>
+    /// <param name="endDate">Optional end date filter.</param>
+    /// <param name="user">Optional user filter.</param>
+    /// <param name="action">Optional action filter.</param>
+    /// <param name="status">Optional status filter.</param>
+    /// <returns>A tuple containing the logs, pagination flag, and end cursor.</returns>
     private async Task<(List<WizAuditLogEntry> Logs, bool HasNextPage, string? EndCursor)> GetAuditLogsPageAsync(
         int first,
         string? after = null,

--- a/WizCloud/WizClient.CloudAccounts.cs
+++ b/WizCloud/WizClient.CloudAccounts.cs
@@ -12,6 +12,9 @@ using System.Threading.Tasks;
 
 namespace WizCloud;
 
+/// <summary>
+/// Provides cloud account operations for <see cref="WizClient"/>.
+/// </summary>
 public partial class WizClient {
     /// <summary>
     /// Retrieves all cloud accounts from Wiz asynchronously.

--- a/WizCloud/WizClient.Compliance.cs
+++ b/WizCloud/WizClient.Compliance.cs
@@ -12,6 +12,12 @@ using System.Threading.Tasks;
 namespace WizCloud;
 
 public partial class WizClient {
+    /// <summary>
+    /// Retrieves compliance posture results from Wiz.
+    /// </summary>
+    /// <param name="frameworks">Optional compliance frameworks filter.</param>
+    /// <param name="minScore">Optional minimum score filter.</param>
+    /// <returns>A list of compliance results.</returns>
     public async Task<List<WizComplianceResult>> GetCompliancePostureAsync(
         IEnumerable<string>? frameworks = null,
         double? minScore = null) {
@@ -40,6 +46,13 @@ public partial class WizClient {
         return results;
     }
 
+    /// <summary>
+    /// Streams compliance posture results from Wiz as an asynchronous sequence.
+    /// </summary>
+    /// <param name="frameworks">Optional compliance frameworks filter.</param>
+    /// <param name="minScore">Optional minimum score filter.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>An async enumerable of compliance results.</returns>
     public async IAsyncEnumerable<WizComplianceResult> GetCompliancePostureAsyncEnumerable(
         IEnumerable<string>? frameworks = null,
         double? minScore = null,

--- a/WizCloud/WizClient.ConfigurationFindings.cs
+++ b/WizCloud/WizClient.ConfigurationFindings.cs
@@ -12,6 +12,15 @@ using System.Threading.Tasks;
 namespace WizCloud;
 
 public partial class WizClient {
+    /// <summary>
+    /// Retrieves configuration findings from Wiz.
+    /// </summary>
+    /// <param name="pageSize">The number of findings to retrieve per page.</param>
+    /// <param name="frameworks">Optional compliance frameworks filter.</param>
+    /// <param name="severities">Optional severity filter.</param>
+    /// <param name="categories">Optional category filter.</param>
+    /// <param name="projectId">Optional project identifier filter.</param>
+    /// <returns>A list of configuration findings.</returns>
     public async Task<List<WizConfigurationFinding>> GetConfigurationFindingsAsync(
         int pageSize = 20,
         IEnumerable<string>? frameworks = null,
@@ -32,6 +41,16 @@ public partial class WizClient {
         return findings;
     }
 
+    /// <summary>
+    /// Streams configuration findings from Wiz as an asynchronous sequence.
+    /// </summary>
+    /// <param name="pageSize">The number of findings to retrieve per page.</param>
+    /// <param name="frameworks">Optional compliance frameworks filter.</param>
+    /// <param name="severities">Optional severity filter.</param>
+    /// <param name="categories">Optional category filter.</param>
+    /// <param name="projectId">Optional project identifier filter.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>An async enumerable of configuration findings.</returns>
     public async IAsyncEnumerable<WizConfigurationFinding> GetConfigurationFindingsAsyncEnumerable(
         int pageSize = 20,
         IEnumerable<string>? frameworks = null,
@@ -62,6 +81,16 @@ public partial class WizClient {
         }
     }
 
+    /// <summary>
+    /// Retrieves a single page of configuration findings from the Wiz API.
+    /// </summary>
+    /// <param name="first">The number of findings to retrieve.</param>
+    /// <param name="after">Cursor for pagination.</param>
+    /// <param name="frameworks">Optional compliance frameworks filter.</param>
+    /// <param name="severities">Optional severity filter.</param>
+    /// <param name="categories">Optional category filter.</param>
+    /// <param name="projectId">Optional project identifier filter.</param>
+    /// <returns>A tuple containing the findings, pagination flag, and end cursor.</returns>
     private async Task<(List<WizConfigurationFinding> Findings, bool HasNextPage, string? EndCursor)> GetConfigurationFindingsPageAsync(
         int first,
         string? after = null,

--- a/WizCloud/WizClient.NetworkExposure.cs
+++ b/WizCloud/WizClient.NetworkExposure.cs
@@ -12,6 +12,15 @@ using System.Threading.Tasks;
 namespace WizCloud;
 
 public partial class WizClient {
+    /// <summary>
+    /// Retrieves network exposures from Wiz.
+    /// </summary>
+    /// <param name="pageSize">The number of exposures to retrieve per page.</param>
+    /// <param name="ports">Optional port filters.</param>
+    /// <param name="protocols">Optional protocol filters.</param>
+    /// <param name="internetFacing">Optional internet-facing filter.</param>
+    /// <param name="projectId">Optional project identifier filter.</param>
+    /// <returns>A list of network exposures.</returns>
     public async Task<List<WizNetworkExposure>> GetNetworkExposuresAsync(
         int pageSize = 20,
         IEnumerable<int>? ports = null,
@@ -32,6 +41,16 @@ public partial class WizClient {
         return exposures;
     }
 
+    /// <summary>
+    /// Streams network exposures from Wiz as an asynchronous sequence.
+    /// </summary>
+    /// <param name="pageSize">The number of exposures to retrieve per page.</param>
+    /// <param name="ports">Optional port filters.</param>
+    /// <param name="protocols">Optional protocol filters.</param>
+    /// <param name="internetFacing">Optional internet-facing filter.</param>
+    /// <param name="projectId">Optional project identifier filter.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>An async enumerable of network exposures.</returns>
     public async IAsyncEnumerable<WizNetworkExposure> GetNetworkExposuresAsyncEnumerable(
         int pageSize = 20,
         IEnumerable<int>? ports = null,
@@ -62,6 +81,16 @@ public partial class WizClient {
         }
     }
 
+    /// <summary>
+    /// Retrieves a single page of network exposures from the Wiz API.
+    /// </summary>
+    /// <param name="first">The number of exposures to retrieve.</param>
+    /// <param name="after">Cursor for pagination.</param>
+    /// <param name="ports">Optional port filters.</param>
+    /// <param name="protocols">Optional protocol filters.</param>
+    /// <param name="internetFacing">Optional internet-facing filter.</param>
+    /// <param name="projectId">Optional project identifier filter.</param>
+    /// <returns>A tuple containing the exposures, pagination flag, and end cursor.</returns>
     private async Task<(List<WizNetworkExposure> Exposures, bool HasNextPage, string? EndCursor)> GetNetworkExposuresPageAsync(
         int first,
         string? after = null,

--- a/WizCloud/WizClient.Resources.cs
+++ b/WizCloud/WizClient.Resources.cs
@@ -13,8 +13,16 @@ namespace WizCloud;
 
 public partial class WizClient {
     /// <summary>
-    /// Retrieves all resources from Wiz asynchronously.
+    /// Retrieves resources from Wiz.
     /// </summary>
+    /// <param name="pageSize">The number of resources to retrieve per page.</param>
+    /// <param name="types">Optional resource type filters.</param>
+    /// <param name="cloudProviders">Optional cloud provider filters.</param>
+    /// <param name="region">Optional region filter.</param>
+    /// <param name="publiclyAccessible">Optional public accessibility filter.</param>
+    /// <param name="tags">Optional tag filters.</param>
+    /// <param name="projectId">Optional project identifier filter.</param>
+    /// <returns>A list of resources.</returns>
     public async Task<List<WizResource>> GetResourcesAsync(
         int pageSize = 20,
         IEnumerable<string>? types = null,
@@ -46,8 +54,17 @@ public partial class WizClient {
     }
 
     /// <summary>
-    /// Streams resources from Wiz asynchronously.
+    /// Streams resources from Wiz as an asynchronous sequence.
     /// </summary>
+    /// <param name="pageSize">The number of resources to retrieve per page.</param>
+    /// <param name="types">Optional resource type filters.</param>
+    /// <param name="cloudProviders">Optional cloud provider filters.</param>
+    /// <param name="region">Optional region filter.</param>
+    /// <param name="publiclyAccessible">Optional public accessibility filter.</param>
+    /// <param name="tags">Optional tag filters.</param>
+    /// <param name="projectId">Optional project identifier filter.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>An async enumerable of resources.</returns>
     public async IAsyncEnumerable<WizResource> GetResourcesAsyncEnumerable(
         int pageSize = 20,
         IEnumerable<string>? types = null,
@@ -91,6 +108,15 @@ public partial class WizClient {
     /// <summary>
     /// Retrieves a single page of resources from the Wiz API.
     /// </summary>
+    /// <param name="first">The number of resources to retrieve.</param>
+    /// <param name="after">Cursor for pagination.</param>
+    /// <param name="types">Optional resource type filters.</param>
+    /// <param name="cloudProviders">Optional cloud provider filters.</param>
+    /// <param name="region">Optional region filter.</param>
+    /// <param name="publiclyAccessible">Optional public accessibility filter.</param>
+    /// <param name="tags">Optional tag filters.</param>
+    /// <param name="projectId">Optional project identifier filter.</param>
+    /// <returns>A tuple containing the resources, pagination flag, and end cursor.</returns>
     private async Task<(List<WizResource> Resources, bool HasNextPage, string? EndCursor)> GetResourcesPageAsync(
         int first,
         string? after = null,


### PR DESCRIPTION
## Summary
- add MatejKafka-compatible XML comments to PowerShell cmdlets to resolve CS1591
- document WizClient helper and query methods across audit, compliance, configuration, network and resource features

## Testing
- `dotnet build --no-restore -t:Rebuild`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689487ff4794832ebd5696f9f620be63