### PR TITLE
docs: add xml help for cmdlets

### DIFF
--- a/WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletConnectWiz.cs
@@ -5,63 +5,54 @@ using System.Threading.Tasks;
 using WizCloud;
 
 namespace WizCloud.PowerShell;
-/// <summary>
-/// <para type="synopsis">Connects to Wiz.io and stores authentication for the session.</para>
-/// <para type="description">The Connect-Wiz cmdlet establishes a connection to Wiz.io and stores the authentication token for use in other Wiz cmdlets during the session. Returns true on success, false on failure.</para>
+/// <summary>Connects to Wiz.io and stores authentication for the session.</summary>
+/// <para>Establishes a connection using a token or client credentials and optionally tests the API.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Stored credentials remain in memory until <c>Disconnect-Wiz</c> is executed.</description>
+/// </item>
+/// </list>
 /// <example>
-/// <para>Connect using a token:</para>
-/// <code>Connect-Wiz -Token "your-service-account-token"</code>
+/// <summary>Connect using a token</summary>
+/// <code><prefix>PS&gt; </prefix>Connect-Wiz -Token 'your-service-account-token'</code>
+/// <para>The token is cached for subsequent cmdlets.</para>
 /// </example>
 /// <example>
-/// <para>Connect to a specific region:</para>
-/// <code>Connect-Wiz -Token "your-service-account-token" -Region "us1"</code>
+/// <summary>Connect with client credentials</summary>
+/// <code><prefix>PS&gt; </prefix>Connect-Wiz -ClientId 'id' -ClientSecret 'secret' -Region us1</code>
+/// <para>A token is acquired for region <c>us1</c>.</para>
 /// </example>
-/// <example>
-/// <para>Connect using client credentials:</para>
-/// <code>Connect-Wiz -ClientId "id" -ClientSecret "secret"</code>
-/// </example>
-/// </summary>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommunications.Connect, "Wiz")]
 [OutputType(typeof(bool))]
 public class CmdletConnectWiz : AsyncPSCmdlet {
     private const string TokenParameterSet = nameof(TokenParameterSet);
     private const string ClientCredentialParameterSet = nameof(ClientCredentialParameterSet);
-    /// <summary>
-    /// <para type="description">The Wiz service account token for authentication.</para>
-    /// </summary>
+    /// <summary>The Wiz service account token for authentication.</summary>
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = TokenParameterSet, HelpMessage = "The Wiz service account token for authentication.")]
     [ValidateNotNullOrEmpty]
     public string? Token { get; set; }
 
-    /// <summary>
-    /// <para type="description">The service account client ID.</para>
-    /// </summary>
+    /// <summary>The service account client ID.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ClientCredentialParameterSet, HelpMessage = "The Wiz service account client ID.")]
     [ValidateNotNullOrEmpty]
     public string? ClientId { get; set; }
 
-    /// <summary>
-    /// <para type="description">The service account client secret.</para>
-    /// </summary>
+    /// <summary>The service account client secret.</summary>
     [Parameter(Mandatory = true, ParameterSetName = ClientCredentialParameterSet, HelpMessage = "The Wiz service account client secret.")]
     [ValidateNotNullOrEmpty]
     public string? ClientSecret { get; set; }
 
-    /// <summary>
-    /// <para type="description">The Wiz region to connect to. Default is 'eu17'.</para>
-    /// </summary>
+    /// <summary>The Wiz region to connect to. Default is 'eu17'.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The Wiz region to connect to (e.g., 'eu17', 'us1', 'us2').")]
     public WizRegion Region { get; set; } = WizRegion.EU17;
 
-    /// <summary>
-    /// <para type="description">Test the connection to Wiz.</para>
-    /// </summary>
+    /// <summary>Tests the connection to Wiz.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Test the connection to Wiz.")]
     public SwitchParameter TestConnection { get; set; }
 
-    /// <summary>
-    /// <para type="description">Suppress the output (returns only true/false).</para>
-    /// </summary>
+    /// <summary>Suppresses informational output and returns only a Boolean result.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Suppress the output messages.")]
     public SwitchParameter Suppress { get; set; }
 

--- a/WizCloud.PowerShell/Cmdlets/CmdletDisconnectWiz.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletDisconnectWiz.cs
@@ -2,14 +2,25 @@ using System.Management.Automation;
 
 namespace WizCloud.PowerShell;
 
-/// <summary>
-/// <para type="synopsis">Clears Wiz authentication from the current session.</para>
-/// <para type="description">The Disconnect-Wiz cmdlet removes stored authentication and client credentials from the session.</para>
+/// <summary>Clears Wiz authentication from the current session.</summary>
+/// <para>Removes stored tokens, credentials, and region information for the session.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Disconnecting deletes authentication details and cannot be undone for the current session.</description>
+/// </item>
+/// </list>
 /// <example>
-/// <para>Disconnect from Wiz:</para>
-/// <code>Disconnect-Wiz</code>
+/// <summary>Disconnect the current session</summary>
+/// <code><prefix>PS&gt; </prefix>Disconnect-Wiz</code>
+/// <para>This example clears any stored Wiz authentication information.</para>
 /// </example>
-/// </summary>
+/// <example>
+/// <summary>Disconnect after connecting</summary>
+/// <code><prefix>PS&gt; </prefix>Connect-Wiz -Token 'token'; Disconnect-Wiz</code>
+/// <para>The connection created with <c>Connect-Wiz</c> is removed.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommunications.Disconnect, "Wiz")]
 [OutputType(typeof(bool))]
 public sealed class CmdletDisconnectWiz : PSCmdlet {

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizAuditLog.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizAuditLog.cs
@@ -7,63 +7,55 @@ using WizCloud;
 
 namespace WizCloud.PowerShell;
 
-/// <summary>
-/// <para type="synopsis">Gets audit logs from Wiz.io.</para>
-/// <para type="description">The Get-WizAuditLog cmdlet retrieves audit log entries from Wiz.io using streaming enumeration.</para>
-/// </summary>
+/// <summary>Gets audit logs from Wiz.io.</summary>
+/// <para>Retrieves records of user actions and system events.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Audit logs may be extensive; apply date or user filters to narrow the output.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Get recent audit logs</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizAuditLog</code>
+/// <para>Returns audit logs using default paging.</para>
+/// </example>
+/// <example>
+/// <summary>Filter by user and date</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizAuditLog -User admin@example.com -StartDate (Get-Date).AddDays(-1)</code>
+/// <para>Retrieves actions for the specified user in the last day.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizAuditLog")]
 [OutputType(typeof(WizAuditLogEntry))]
 public class CmdletGetWizAuditLog : AsyncPSCmdlet {
-    /// <summary>
-    /// <para type="description">The number of audit logs to retrieve per page. Default is 500.</para>
-    /// </summary>
+    /// <summary>The number of audit logs to retrieve per page. Default is 500.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The number of audit logs to retrieve per page.")]
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
-
-    /// <summary>
-    /// <para type="description">Filter audit logs by start date.</para>
-    /// </summary>
+    /// <summary>Filter audit logs by start date.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by start date.")]
     public DateTime? StartDate { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter audit logs by end date.</para>
-    /// </summary>
+    /// <summary>Filter audit logs by end date.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by end date.")]
     public DateTime? EndDate { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter audit logs by user.</para>
-    /// </summary>
+    /// <summary>Filter audit logs by user.</summary>
     [Parameter(Mandatory = false, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by user.")]
     public string? User { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter audit logs by action.</para>
-    /// </summary>
+    /// <summary>Filter audit logs by action.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by action.")]
     public string? Action { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter audit logs by status.</para>
-    /// </summary>
+    /// <summary>Filter audit logs by status.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by status.")]
     public string? Status { get; set; }
-
-    /// <summary>
-    /// <para type="description">Maximum number of audit logs to retrieve. Default is unlimited.</para>
-    /// </summary>
+    /// <summary>Maximum number of audit logs to retrieve. Default is unlimited.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of audit logs to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
 
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
-
-    /// <summary>
-    /// <para type="description">Initializes the Wiz client for audit log retrieval.</para>
-    /// </summary>
+    /// <summary>Initializes the Wiz client for audit log retrieval.</summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -103,10 +95,7 @@ public class CmdletGetWizAuditLog : AsyncPSCmdlet {
 
         return Task.CompletedTask;
     }
-
-    /// <summary>
-    /// <para type="description">Processes the Get-WizAuditLog command.</para>
-    /// </summary>
+    /// <summary>Processes the Get-WizAuditLog command.</summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -165,10 +154,7 @@ public class CmdletGetWizAuditLog : AsyncPSCmdlet {
                 null));
         }
     }
-
-    /// <summary>
-    /// <para type="description">Releases the Wiz client resources.</para>
-    /// </summary>
+    /// <summary>Releases the Wiz client resources.</summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizCloudAccount.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizCloudAccount.cs
@@ -6,31 +6,33 @@ using System.Threading.Tasks;
 using WizCloud;
 
 namespace WizCloud.PowerShell;
-/// <summary>
-/// <para type="synopsis">Gets cloud accounts from Wiz.io.</para>
-/// <para type="description">The Get-WizCloudAccount cmdlet retrieves cloud accounts from Wiz.io including AWS, Azure, and GCP accounts.</para>
+/// <summary>Gets cloud accounts from Wiz.io.</summary>
+/// <para>Enumerates cloud provider accounts linked to your organization.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Retrieving many accounts may trigger API rate limiting.</description>
+/// </item>
+/// </list>
 /// <example>
-/// <para>Get all cloud accounts from Wiz:</para>
-/// <code>Get-WizCloudAccount</code>
+/// <summary>Get all cloud accounts</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizCloudAccount</code>
+/// <para>Lists every account accessible to the current connection.</para>
 /// </example>
 /// <example>
-/// <para>Get limited number of cloud accounts:</para>
-/// <code>Get-WizCloudAccount -MaxResults 50 -PageSize 50</code>
+/// <summary>Limit the number of accounts</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizCloudAccount -MaxResults 50 -PageSize 50</code>
+/// <para>Retrieves at most fifty accounts in pages of fifty.</para>
 /// </example>
-/// </summary>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizCloudAccount")]
 [OutputType(typeof(WizCloudAccount))]
 public class CmdletGetWizCloudAccount : AsyncPSCmdlet {
-    /// <summary>
-    /// <para type="description">The number of cloud accounts to retrieve per page. Default is 500.</para>
-    /// </summary>
+    /// <summary>The number of cloud accounts to retrieve per page. Default is 500.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The number of cloud accounts to retrieve per page.")]
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
-
-    /// <summary>
-    /// <para type="description">The maximum number of cloud accounts to retrieve. Use this to limit results when dealing with large datasets.</para>
-    /// </summary>
+    /// <summary>The maximum number of cloud accounts to retrieve. Use this to limit results when dealing with large datasets.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of cloud accounts to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizCompliance.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizCompliance.cs
@@ -7,31 +7,38 @@ using WizCloud;
 
 namespace WizCloud.PowerShell;
 
-/// <summary>
-/// <para type="synopsis">Gets compliance posture from Wiz.io.</para>
-/// <para type="description">The Get-WizCompliance cmdlet retrieves compliance posture results from Wiz.io.</para>
-/// </summary>
+/// <summary>Gets compliance posture from Wiz.io.</summary>
+/// <para>Retrieves compliance scores for supported frameworks.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Results represent the latest assessment and may change as new scans run.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Get compliance posture</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizCompliance</code>
+/// <para>Returns compliance scores for all available frameworks.</para>
+/// </example>
+/// <example>
+/// <summary>Filter by framework and score</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizCompliance -Framework CIS -MinScore 80</code>
+/// <para>Shows CIS results with scores of at least 80.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizCompliance")]
 [OutputType(typeof(WizComplianceResult))]
 public class CmdletGetWizCompliance : AsyncPSCmdlet {
-    /// <summary>
-    /// <para type="description">Filter compliance results by framework.</para>
-    /// </summary>
+    /// <summary>Filter compliance results by framework.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by compliance framework.")]
     public string[] Framework { get; set; } = Array.Empty<string>();
-
-    /// <summary>
-    /// <para type="description">Filter results by minimum compliance score.</para>
-    /// </summary>
+    /// <summary>Filter results by minimum compliance score.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by minimum compliance score.")]
     public double? MinScore { get; set; }
 
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
-
-    /// <summary>
-    /// <para type="description">Initializes the Wiz client for compliance retrieval.</para>
-    /// </summary>
+    /// <summary>Initializes the Wiz client for compliance retrieval.</summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -71,10 +78,7 @@ public class CmdletGetWizCompliance : AsyncPSCmdlet {
 
         return Task.CompletedTask;
     }
-
-    /// <summary>
-    /// <para type="description">Processes the Get-WizCompliance command.</para>
-    /// </summary>
+    /// <summary>Processes the Get-WizCompliance command.</summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -122,10 +126,7 @@ public class CmdletGetWizCompliance : AsyncPSCmdlet {
                 null));
         }
     }
-
-    /// <summary>
-    /// <para type="description">Releases the Wiz client resources.</para>
-    /// </summary>
+    /// <summary>Releases the Wiz client resources.</summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizConfigurationFinding.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizConfigurationFinding.cs
@@ -7,57 +7,52 @@ using WizCloud;
 
 namespace WizCloud.PowerShell;
 
-/// <summary>
-/// <para type="synopsis">Gets configuration findings from Wiz.io.</para>
-/// <para type="description">The Get-WizConfigurationFinding cmdlet retrieves configuration assessment findings from Wiz.io using streaming enumeration.</para>
-/// </summary>
+/// <summary>Gets configuration findings from Wiz.io.</summary>
+/// <para>Retrieves configuration assessment results from the Wiz platform.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Use filters such as framework or severity to limit the amount of data returned.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Get configuration findings</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizConfigurationFinding</code>
+/// <para>Returns all available configuration findings.</para>
+/// </example>
+/// <example>
+/// <summary>Filter by framework</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizConfigurationFinding -Framework CIS</code>
+/// <para>Retrieves findings related to the CIS framework.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizConfigurationFinding")]
 [OutputType(typeof(WizConfigurationFinding))]
 public class CmdletGetWizConfigurationFinding : AsyncPSCmdlet {
-    /// <summary>
-    /// <para type="description">The number of findings to retrieve per page. Default is 500.</para>
-    /// </summary>
+    /// <summary>The number of findings to retrieve per page. Default is 500.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The number of findings to retrieve per page.")]
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
-
-    /// <summary>
-    /// <para type="description">Filter configuration findings by compliance framework.</para>
-    /// </summary>
+    /// <summary>Filter configuration findings by compliance framework.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by compliance framework.")]
     public string[] Framework { get; set; } = Array.Empty<string>();
-
-    /// <summary>
-    /// <para type="description">Filter findings by severity.</para>
-    /// </summary>
+    /// <summary>Filter findings by severity.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by severity.")]
     public WizSeverity[] Severity { get; set; } = Array.Empty<WizSeverity>();
-
-    /// <summary>
-    /// <para type="description">Filter findings by category.</para>
-    /// </summary>
+    /// <summary>Filter findings by category.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by category.")]
     public string[] Category { get; set; } = Array.Empty<string>();
-
-    /// <summary>
-    /// <para type="description">Filter findings by project identifier.</para>
-    /// </summary>
+    /// <summary>Filter findings by project identifier.</summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
-
-    /// <summary>
-    /// <para type="description">Maximum number of findings to retrieve. Default is unlimited.</para>
-    /// </summary>
+    /// <summary>Maximum number of findings to retrieve. Default is unlimited.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of findings to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
 
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
-
-    /// <summary>
-    /// <para type="description">Initializes the Wiz client for configuration findings.</para>
-    /// </summary>
+    /// <summary>Initializes the Wiz client for configuration findings.</summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -97,10 +92,7 @@ public class CmdletGetWizConfigurationFinding : AsyncPSCmdlet {
 
         return Task.CompletedTask;
     }
-
-    /// <summary>
-    /// <para type="description">Processes the Get-WizConfigurationFinding command.</para>
-    /// </summary>
+    /// <summary>Processes the Get-WizConfigurationFinding command.</summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -159,10 +151,7 @@ public class CmdletGetWizConfigurationFinding : AsyncPSCmdlet {
                 null));
         }
     }
-
-    /// <summary>
-    /// <para type="description">Releases the Wiz client resources.</para>
-    /// </summary>
+    /// <summary>Releases the Wiz client resources.</summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizIssue.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizIssue.cs
@@ -7,51 +7,45 @@ using WizCloud;
 
 namespace WizCloud.PowerShell;
 
-/// <summary>
-/// <para type="synopsis">Gets security issues from Wiz.io.</para>
-/// <para type="description">The Get-WizIssue cmdlet retrieves security issues from Wiz.io using streaming enumeration.</para>
+/// <summary>Gets security issues from Wiz.io.</summary>
+/// <para>Streams security issues reported by the Wiz platform.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Retrieving all issues may produce a large volume of output and take considerable time.</description>
+/// </item>
+/// </list>
 /// <example>
-/// <para>Get all issues from Wiz:</para>
-/// <code>Get-WizIssue</code>
+/// <summary>Get all issues</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizIssue</code>
+/// <para>Returns every issue available to the current connection.</para>
 /// </example>
-/// </summary>
+/// <example>
+/// <summary>Filter by severity</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizIssue -Severity High</code>
+/// <para>Retrieves only high-severity issues.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizIssue")]
 [OutputType(typeof(WizIssue))]
 public class CmdletGetWizIssue : AsyncPSCmdlet {
-    /// <summary>
-    /// <para type="description">The number of issues to retrieve per page. Default is 20.</para>
-    /// </summary>
+    /// <summary>The number of issues to retrieve per page. Default is 20.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The number of issues to retrieve per page.")]
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
-
-    /// <summary>
-    /// <para type="description">Filter issues by severity.</para>
-    /// </summary>
+    /// <summary>Filter issues by severity.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by issue severities.")]
     public WizSeverity[] Severity { get; set; } = Array.Empty<WizSeverity>();
-
-    /// <summary>
-    /// <para type="description">Filter issues by status.</para>
-    /// </summary>
+    /// <summary>Filter issues by status.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by issue status.")]
     public string[] Status { get; set; } = Array.Empty<string>();
-
-    /// <summary>
-    /// <para type="description">Filter issues by project identifier.</para>
-    /// </summary>
+    /// <summary>Filter issues by project identifier.</summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter issues by type.</para>
-    /// </summary>
+    /// <summary>Filter issues by type.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by issue types.")]
     public string[] Type { get; set; } = Array.Empty<string>();
-
-    /// <summary>
-    /// <para type="description">The maximum number of issues to retrieve. Default is unlimited.</para>
-    /// </summary>
+    /// <summary>The maximum number of issues to retrieve. Default is unlimited.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of issues to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizNetworkExposure.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizNetworkExposure.cs
@@ -7,57 +7,52 @@ using WizCloud;
 
 namespace WizCloud.PowerShell;
 
-/// <summary>
-/// <para type="synopsis">Gets network exposure data from Wiz.io.</para>
-/// <para type="description">The Get-WizNetworkExposure cmdlet retrieves network exposure information from Wiz.io using streaming enumeration.</para>
-/// </summary>
+/// <summary>Gets network exposure data from Wiz.io.</summary>
+/// <para>Retrieves open port and protocol exposure information.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Use port or protocol filters to limit the volume of returned data.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Get all network exposures</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizNetworkExposure</code>
+/// <para>Returns every network exposure record.</para>
+/// </example>
+/// <example>
+/// <summary>Filter by port and protocol</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizNetworkExposure -Port 443 -Protocol tcp</code>
+/// <para>Retrieves exposures for TCP port 443.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizNetworkExposure")]
 [OutputType(typeof(WizNetworkExposure))]
 public class CmdletGetWizNetworkExposure : AsyncPSCmdlet {
-    /// <summary>
-    /// <para type="description">The number of exposures to retrieve per page. Default is 500.</para>
-    /// </summary>
+    /// <summary>The number of exposures to retrieve per page. Default is 500.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The number of exposures to retrieve per page.")]
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
-
-    /// <summary>
-    /// <para type="description">Filter exposures by port.</para>
-    /// </summary>
+    /// <summary>Filter exposures by port.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by port.")]
     public int[] Port { get; set; } = Array.Empty<int>();
-
-    /// <summary>
-    /// <para type="description">Filter exposures by protocol.</para>
-    /// </summary>
+    /// <summary>Filter exposures by protocol.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by protocol.")]
     public string[] Protocol { get; set; } = Array.Empty<string>();
-
-    /// <summary>
-    /// <para type="description">Filter exposures by internet-facing status.</para>
-    /// </summary>
+    /// <summary>Filter exposures by internet-facing status.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by internet facing status.")]
     public bool? InternetFacing { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter exposures by project identifier.</para>
-    /// </summary>
+    /// <summary>Filter exposures by project identifier.</summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
-
-    /// <summary>
-    /// <para type="description">Maximum number of exposures to retrieve. Default is unlimited.</para>
-    /// </summary>
+    /// <summary>Maximum number of exposures to retrieve. Default is unlimited.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of exposures to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
 
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
-
-    /// <summary>
-    /// <para type="description">Initializes the Wiz client for network exposure retrieval.</para>
-    /// </summary>
+    /// <summary>Initializes the Wiz client for network exposure retrieval.</summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -97,10 +92,7 @@ public class CmdletGetWizNetworkExposure : AsyncPSCmdlet {
 
         return Task.CompletedTask;
     }
-
-    /// <summary>
-    /// <para type="description">Processes the Get-WizNetworkExposure command.</para>
-    /// </summary>
+    /// <summary>Processes the Get-WizNetworkExposure command.</summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -159,10 +151,7 @@ public class CmdletGetWizNetworkExposure : AsyncPSCmdlet {
                 null));
         }
     }
-
-    /// <summary>
-    /// <para type="description">Releases the Wiz client resources.</para>
-    /// </summary>
+    /// <summary>Releases the Wiz client resources.</summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizProject.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizProject.cs
@@ -6,36 +6,33 @@ using System.Threading.Tasks;
 using WizCloud;
 
 namespace WizCloud.PowerShell;
-/// <summary>
-/// <para type="synopsis">Gets projects from Wiz.io.</para>
-/// <para type="description">The Get-WizProject cmdlet retrieves projects from Wiz.io using streaming enumeration.</para>
+/// <summary>Gets projects from Wiz.io.</summary>
+/// <para>Retrieves project and folder information from the Wiz API.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Projects are returned in pages and may include folder entries.</description>
+/// </item>
+/// </list>
 /// <example>
-/// <para>Get all projects from Wiz:</para>
-/// <code>Get-WizProject</code>
+/// <summary>Get all projects</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizProject</code>
+/// <para>Returns every project for the connected organization.</para>
 /// </example>
 /// <example>
-/// <para>Get projects with a specific page size:</para>
-/// <code>Get-WizProject -PageSize 100</code>
+/// <summary>Specify page size</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizProject -PageSize 100</code>
+/// <para>Retrieves projects in pages of one hundred.</para>
 /// </example>
-/// <example>
-/// <para>Select a region using Connect-Wiz and then retrieve projects:</para>
-/// <code>Connect-Wiz -Region "us1"; Get-WizProject</code>
-/// </example>
-/// </summary>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizProject")]
 [OutputType(typeof(WizProject))]
 public class CmdletGetWizProject : AsyncPSCmdlet {
-
-    /// <summary>
-    /// <para type="description">The number of projects to retrieve per page. Default is 20.</para>
-    /// </summary>
+    /// <summary>The number of projects to retrieve per page. Default is 20.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The number of projects to retrieve per page.")]
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
-
-    /// <summary>
-    /// <para type="description">The maximum number of projects to retrieve. Use this to limit results when dealing with large datasets.</para>
-    /// </summary>
+    /// <summary>The maximum number of projects to retrieve. Use this to limit results when dealing with large datasets.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of projects to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizResource.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizResource.cs
@@ -8,69 +8,58 @@ using System.Threading.Tasks;
 using WizCloud;
 
 namespace WizCloud.PowerShell;
-/// <summary>
-/// <para type="synopsis">Gets cloud resources from Wiz.io.</para>
-/// <para type="description">The Get-WizResource cmdlet retrieves resources from Wiz.io inventory.</para>
-/// </summary>
+/// <summary>Gets cloud resources from Wiz.io.</summary>
+/// <para>Retrieves resource inventory items from the Wiz API.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Large result sets may require multiple API requests and increase run time.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Get all resources</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizResource</code>
+/// <para>Returns all resources visible to the current connection.</para>
+/// </example>
+/// <example>
+/// <summary>Filter by type and page size</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizResource -Type vm -PageSize 100</code>
+/// <para>Retrieves virtual machines 100 at a time.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizResource")]
 [OutputType(typeof(WizResource))]
 public class CmdletGetWizResource : AsyncPSCmdlet {
-    /// <summary>
-    /// <para type="description">The number of resources to retrieve per page. Default is 500.</para>
-    /// </summary>
+    /// <summary>The number of resources to retrieve per page. Default is 500.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The number of resources to retrieve per page.")]
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
-
-    /// <summary>
-    /// <para type="description">Filter resources by type.</para>
-    /// </summary>
+    /// <summary>Filter resources by type.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by resource type.")]
     public string[] Type { get; set; } = Array.Empty<string>();
-
-    /// <summary>
-    /// <para type="description">Filter resources by cloud provider.</para>
-    /// </summary>
+    /// <summary>Filter resources by cloud provider.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by cloud provider.")]
     public WizCloudProvider[] CloudProvider { get; set; } = Array.Empty<WizCloudProvider>();
-
-    /// <summary>
-    /// <para type="description">Filter resources by region.</para>
-    /// </summary>
+    /// <summary>Filter resources by region.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by resource region.")]
     public string? Region { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter resources by public accessibility.</para>
-    /// </summary>
+    /// <summary>Filter resources by public accessibility.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by public accessibility.")]
     public SwitchParameter PubliclyAccessible { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter resources by tag.</para>
-    /// </summary>
+    /// <summary>Filter resources by tag.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by tags.")]
     public Hashtable? Tag { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter resources by project identifier.</para>
-    /// </summary>
+    /// <summary>Filter resources by project identifier.</summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
-
-    /// <summary>
-    /// <para type="description">Maximum number of resources to retrieve. Default is unlimited.</para>
-    /// </summary>
+    /// <summary>Maximum number of resources to retrieve. Default is unlimited.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of resources to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
 
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
-
-    /// <summary>
-    /// <para type="description">Initializes the Wiz client for resource retrieval.</para>
-    /// </summary>
+    /// <summary>Initializes the Wiz client for resource retrieval.</summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -109,10 +98,7 @@ public class CmdletGetWizResource : AsyncPSCmdlet {
 
         return Task.CompletedTask;
     }
-
-    /// <summary>
-    /// <para type="description">Processes the Get-WizResource command.</para>
-    /// </summary>
+    /// <summary>Processes the Get-WizResource command.</summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -187,10 +173,7 @@ public class CmdletGetWizResource : AsyncPSCmdlet {
                 null));
         }
     }
-
-    /// <summary>
-    /// <para type="description">Releases the Wiz client resources.</para>
-    /// </summary>
+    /// <summary>Releases the Wiz client resources.</summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizUser.cs
@@ -6,55 +6,43 @@ using System.Threading.Tasks;
 using WizCloud;
 
 namespace WizCloud.PowerShell;
-/// <summary>
-/// <para type="synopsis">Gets users from Wiz.io with all their properties.</para>
-/// <para type="description">The Get-WizUser cmdlet retrieves users from Wiz.io including their security properties, projects, cloud accounts, and issue analytics. By default, returns enhanced user objects with all properties exposed. Use -Raw to get the original API response.</para>
+/// <summary>Gets users from Wiz.io.</summary>
+/// <para>Retrieves user identities along with security properties and related projects.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Using <c>-Raw</c> returns original API objects and may consume additional memory.</description>
+/// </item>
+/// </list>
 /// <example>
-/// <para>Select a region using Connect-Wiz and get all users from Wiz:</para>
-/// <code>Connect-Wiz -Region "us1"; Get-WizUser</code>
+/// <summary>Get all users</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizUser</code>
+/// <para>Retrieves enhanced user objects for the current connection.</para>
 /// </example>
 /// <example>
-/// <para>Select a region using Connect-Wiz and retrieve a limited number of users:</para>
-/// <code>Connect-Wiz -Region "us1"; Get-WizUser -MaxResults 1000 -PageSize 500</code>
+/// <summary>Limit results and return raw objects</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizUser -MaxResults 10 -Raw</code>
+/// <para>Outputs the first ten users using the raw API response.</para>
 /// </example>
-/// <example>
-/// <para>Select a region using Connect-Wiz and get raw API response objects:</para>
-/// <code>Connect-Wiz -Region "us1"; Get-WizUser -Raw -MaxResults 10</code>
-/// </example>
-/// </summary>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizUser")]
 [OutputType(typeof(WizUserComprehensive), typeof(WizUser))]
 public class CmdletGetWizUser : AsyncPSCmdlet {
-
-    /// <summary>
-    /// <para type="description">The number of users to retrieve per page. Default is 20.</para>
-    /// </summary>
+    /// <summary>The number of users to retrieve per page. Default is 20.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The number of users to retrieve per page.")]
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
-
-    /// <summary>
-    /// <para type="description">Filter users by Wiz user type.</para>
-    /// </summary>
+    /// <summary>Filter users by Wiz user type.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by Wiz user types.")]
     public WizUserType[] Type { get; set; } = Array.Empty<WizUserType>();
-
-    /// <summary>
-    /// <para type="description">Filter users by project identifier.</para>
-    /// </summary>
+    /// <summary>Filter users by project identifier.</summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
-
-    /// <summary>
-    /// <para type="description">The maximum number of users to retrieve. Use this to limit results when dealing with large datasets.</para>
-    /// </summary>
+    /// <summary>The maximum number of users to retrieve. Use this to limit results when dealing with large datasets.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of users to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
-
-    /// <summary>
-    /// <para type="description">Return raw API response objects without additional property expansion.</para>
-    /// </summary>
+    /// <summary>Return raw API response objects without additional property expansion.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Return raw API response objects.")]
     public SwitchParameter Raw { get; set; }
 

--- a/WizCloud.PowerShell/Cmdlets/CmdletGetWizVulnerability.cs
+++ b/WizCloud.PowerShell/Cmdlets/CmdletGetWizVulnerability.cs
@@ -7,57 +7,52 @@ using WizCloud;
 
 namespace WizCloud.PowerShell;
 
-/// <summary>
-/// <para type="synopsis">Gets vulnerabilities from Wiz.io.</para>
-/// <para type="description">The Get-WizVulnerability cmdlet retrieves vulnerabilities from Wiz.io using streaming enumeration.</para>
-/// </summary>
+/// <summary>Gets vulnerabilities from Wiz.io.</summary>
+/// <para>Retrieves vulnerability information for resources.</para>
+/// <list type="alertSet">
+/// <item>
+/// <description>Use filters such as <c>-CVE</c> or <c>-ExploitAvailable</c> to reduce result volume.</description>
+/// </item>
+/// </list>
+/// <example>
+/// <summary>Get all vulnerabilities</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizVulnerability</code>
+/// <para>Returns every vulnerability visible to the connection.</para>
+/// </example>
+/// <example>
+/// <summary>Retrieve a specific CVE</summary>
+/// <code><prefix>PS&gt; </prefix>Get-WizVulnerability -CVE CVE-2024-0001</code>
+/// <para>Displays details for the specified CVE.</para>
+/// </example>
+/// <seealso href="https://learn.microsoft.com/powershell/scripting/overview">PowerShell documentation</seealso>
+/// <seealso href="https://github.com/EvotecIT/WizCloud">Project documentation</seealso>
 [Cmdlet(VerbsCommon.Get, "WizVulnerability")]
 [OutputType(typeof(WizVulnerability))]
 public class CmdletGetWizVulnerability : AsyncPSCmdlet {
-    /// <summary>
-    /// <para type="description">The number of vulnerabilities to retrieve per page. Default is 500.</para>
-    /// </summary>
+    /// <summary>The number of vulnerabilities to retrieve per page. Default is 500.</summary>
     [Parameter(Mandatory = false, HelpMessage = "The number of vulnerabilities to retrieve per page.")]
     [ValidateRange(1, 5000)]
     public int PageSize { get; set; } = 500;
-
-    /// <summary>
-    /// <para type="description">Filter vulnerabilities by CVE identifier.</para>
-    /// </summary>
+    /// <summary>Filter vulnerabilities by CVE identifier.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by CVE identifier.")]
     public string? CVE { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter vulnerabilities by minimum CVSS score.</para>
-    /// </summary>
+    /// <summary>Filter vulnerabilities by minimum CVSS score.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter by minimum CVSS score.")]
     public double? MinCVSS { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter to vulnerabilities with an available exploit.</para>
-    /// </summary>
+    /// <summary>Filter to vulnerabilities with an available exploit.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Filter to vulnerabilities with an available exploit.")]
     public SwitchParameter ExploitAvailable { get; set; }
-
-    /// <summary>
-    /// <para type="description">Filter vulnerabilities by project identifier.</para>
-    /// </summary>
+    /// <summary>Filter vulnerabilities by project identifier.</summary>
     [Parameter(Mandatory = false, ValueFromPipelineByPropertyName = true, HelpMessage = "Filter by project identifier.")]
     public string? ProjectId { get; set; }
-
-    /// <summary>
-    /// <para type="description">The maximum number of vulnerabilities to retrieve. Default is unlimited.</para>
-    /// </summary>
+    /// <summary>The maximum number of vulnerabilities to retrieve. Default is unlimited.</summary>
     [Parameter(Mandatory = false, HelpMessage = "Maximum number of vulnerabilities to retrieve. Default is unlimited.")]
     [ValidateRange(1, int.MaxValue)]
     public int? MaxResults { get; set; }
 
     private WizClient? _wizClient;
     private int _retrievedCount = 0;
-
-    /// <summary>
-    /// <para type="description">Initializes the Wiz client for vulnerability retrieval.</para>
-    /// </summary>
+    /// <summary>Initializes the Wiz client for vulnerability retrieval.</summary>
     protected override Task BeginProcessingAsync() {
         try {
             var token = ModuleInitialization.DefaultToken;
@@ -97,10 +92,7 @@ public class CmdletGetWizVulnerability : AsyncPSCmdlet {
 
         return Task.CompletedTask;
     }
-
-    /// <summary>
-    /// <para type="description">Processes the Get-WizVulnerability command.</para>
-    /// </summary>
+    /// <summary>Processes the Get-WizVulnerability command.</summary>
     protected override async Task ProcessRecordAsync() {
         if (_wizClient == null) {
             WriteError(new ErrorRecord(
@@ -165,10 +157,7 @@ public class CmdletGetWizVulnerability : AsyncPSCmdlet {
                 null));
         }
     }
-
-    /// <summary>
-    /// <para type="description">Releases the Wiz client resources.</para>
-    /// </summary>
+    /// <summary>Releases the Wiz client resources.</summary>
     protected override Task EndProcessingAsync() {
         _wizClient?.Dispose();
         return Task.CompletedTask;

--- a/WizCloud.PowerShell/WizCloud.PowerShell.csproj
+++ b/WizCloud.PowerShell/WizCloud.PowerShell.csproj
@@ -29,6 +29,10 @@
     </PropertyGroup>
 
     <PropertyGroup>
+        <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     </PropertyGroup>
 


### PR DESCRIPTION
## Summary
- document each WizCloud PowerShell cmdlet with synopsis, description, notes, examples and references
- enable strict XML documentation generation for cmdlet help

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6896411edd24832ea77527a1698b0b76