### PR TITLE
Add Codecov upload to CI pipeline

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,7 +40,8 @@ jobs:
         run: dotnet build WizCloud.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
       - name: Run tests
-        run: dotnet test WizCloud.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+        run: |
+          dotnet test WizCloud.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
         timeout-minutes: 10
 
       - name: Upload test results
@@ -58,9 +59,13 @@ jobs:
           path: '**/coverage.cobertura.xml'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: '**/coverage.cobertura.xml'
+          flags: windows
+          disable_search: true
           fail_ci_if_error: false
           verbose: true
 
@@ -84,7 +89,8 @@ jobs:
         run: dotnet build WizCloud.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
       - name: Run tests
-        run: dotnet test WizCloud.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+        run: |
+          dotnet test WizCloud.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
         timeout-minutes: 10
 
       - name: Upload test results
@@ -95,9 +101,13 @@ jobs:
           path: '**/*.trx'
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: '**/coverage.cobertura.xml'
+          flags: ubuntu
+          disable_search: true
           fail_ci_if_error: false
           verbose: true
 


### PR DESCRIPTION
## Summary
- configure the Windows and Ubuntu workflows to upload coverage results to Codecov using the v4 action
- keep Codecov status informational by disabling search and passing the Codecov token when available

## Testing
- `dotnet test WizCloud.sln --configuration Release`


------
https://chatgpt.com/codex/tasks/task_e_68caba36fc34832e9a8e14cf29c57c71