### PR TITLE
Add NuGet package metadata to project files

### DIFF
--- a/WizCloud.PowerShell/WizCloud.PowerShell.csproj
+++ b/WizCloud.PowerShell/WizCloud.PowerShell.csproj
@@ -20,6 +20,16 @@
         <Authors>Przemyslaw Klys</Authors>
         <Copyright>(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.</Copyright>
         <LangVersion>Latest</LangVersion>
+        <PackageId>WizCloud.PowerShell</PackageId>
+        <Title>WizCloud PowerShell</Title>
+        <Description>PowerShell module built on the WizCloud client library to interact with the Wiz.io GraphQL API.</Description>
+        <PackageTags>wiz;wizcloud;powershell;wiz.io;graphql;api;security;cloud</PackageTags>
+        <PackageProjectUrl>https://github.com/EvotecIT/WizCloud</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/EvotecIT/WizCloud</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
     </PropertyGroup>
 
 

--- a/WizCloud/WizCloud.csproj
+++ b/WizCloud/WizCloud.csproj
@@ -6,6 +6,20 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <LangVersion>latest</LangVersion>
+    <PackageId>WizCloud</PackageId>
+    <Title>WizCloud</Title>
+    <Version>1.0.0</Version>
+    <Authors>Przemyslaw Klys</Authors>
+    <Company>Evotec</Company>
+    <Product>WizCloud</Product>
+    <Description>Modern asynchronous Wiz.io client for .NET, providing strongly typed access to the Wiz GraphQL API.</Description>
+    <PackageTags>wiz;wizcloud;wiz.io;graphql;api;security;cloud</PackageTags>
+    <PackageProjectUrl>https://github.com/EvotecIT/WizCloud</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/EvotecIT/WizCloud</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">


### PR DESCRIPTION
## Summary
- add NuGet package metadata (id, version, description, license, repository info) to the WizCloud client library
- provide matching NuGet metadata on the PowerShell project to keep packaging information consistent

## Testing
- dotnet build WizCloud.sln

------
https://chatgpt.com/codex/tasks/task_e_68cabbc22ec0832eb90b5615244df097