### PR TITLE
Use GitHub-hosted runners for CI

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   test-windows:
     name: 'Windows'
-    runs-on: [self-hosted, windows]
+    runs-on: windows-latest
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -71,7 +71,7 @@ jobs:
 
   test-ubuntu:
     name: 'Ubuntu'
-    runs-on: [self-hosted, ubuntu]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -112,9 +112,8 @@ jobs:
           verbose: true
 
   test-macos:
-    if: false
     name: 'macOS'
-    runs-on: [self-hosted, macos]
+    runs-on: macos-latest
     timeout-minutes: 20
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- switch CI jobs to use GitHub-hosted Windows, Ubuntu, and macOS runners
- re-enable the macOS test job alongside the existing Windows and Ubuntu jobs

## Testing
- dotnet test WizCloud.sln

------
https://chatgpt.com/codex/tasks/task_e_68cac4abb2e8832eafe8d75c0efd2cec