### PR TITLE
Use PowerForge native documentation

### DIFF
--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -55,11 +55,11 @@
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $true
+        SignModule                        = if ([string]::IsNullOrWhiteSpace($Env:SignModule)) { $true } else { [bool]::Parse($Env:SignModule) }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
         CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
@@ -72,7 +72,8 @@
         NETFramework                      = 'net472', 'net8.0'
         DotSourceLibraries                = $true
         NETSearchClass                    = 'WizCloud.PowerShell.CmdletResolveDnsQuery'
-        RefreshPSD1Only                   = $true
+        RefreshPSD1Only                   = $false
+        NETBinaryModuleDocumentation      = $true
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Module/Docs/Connect-Wiz.md
+++ b/Module/Docs/Connect-Wiz.md
@@ -1,0 +1,159 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Connect-Wiz
+## SYNOPSIS
+Connects to Wiz.io and stores authentication for the session.
+
+## SYNTAX
+### TokenParameterSet
+```powershell
+Connect-Wiz [-Token] <string> [-Region <WizRegion>] [-TestConnection] [-Suppress] [<CommonParameters>]
+```
+
+### ClientCredentialParameterSet
+```powershell
+Connect-Wiz -ClientId <string> -ClientSecret <string> [-Region <WizRegion>] [-TestConnection] [-Suppress] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Establishes a connection using a token or client credentials and optionally tests the API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Connect-Wiz -Token 'your-service-account-token'
+```
+
+The token is cached for subsequent cmdlets.
+
+### EXAMPLE 2
+```powershell
+PS> Connect-Wiz -ClientId 'id' -ClientSecret 'secret' -Region us1
+```
+
+A token is acquired for region us1.
+
+## PARAMETERS
+
+### -ClientId
+The Wiz service account client ID.
+
+```yaml
+Type: String
+Parameter Sets: ClientCredentialParameterSet
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClientSecret
+The Wiz service account client secret.
+
+```yaml
+Type: String
+Parameter Sets: ClientCredentialParameterSet
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Region
+The Wiz region to connect to (e.g., 'eu17', 'us1', 'us2').
+
+```yaml
+Type: WizRegion
+Parameter Sets: TokenParameterSet, ClientCredentialParameterSet
+Aliases: None
+Possible values: EU1, EU2, EU17, US1, US2, USGOV1, AP1, AP2, CA1
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Suppress
+Suppress the output messages.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: TokenParameterSet, ClientCredentialParameterSet
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TestConnection
+Test the connection to Wiz.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: TokenParameterSet, ClientCredentialParameterSet
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Token
+The Wiz service account token for authentication.
+
+```yaml
+Type: String
+Parameter Sets: TokenParameterSet
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `System.Boolean`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Stored credentials remain in memory until Disconnect-Wiz is executed.

--- a/Module/Docs/Disconnect-Wiz.md
+++ b/Module/Docs/Disconnect-Wiz.md
@@ -1,0 +1,58 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Disconnect-Wiz
+## SYNOPSIS
+Clears Wiz authentication from the current session.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Disconnect-Wiz [<CommonParameters>]
+```
+
+## DESCRIPTION
+Removes stored tokens, credentials, and region information for the session.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Disconnect-Wiz
+```
+
+This example clears any stored Wiz authentication information.
+
+### EXAMPLE 2
+```powershell
+PS> Connect-Wiz -Token 'token'; Disconnect-Wiz
+```
+
+The connection created with Connect-Wiz is removed.
+
+## PARAMETERS
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `System.Boolean`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Disconnecting deletes authentication details and cannot be undone for the current session.

--- a/Module/Docs/Get-WizAuditLog.md
+++ b/Module/Docs/Get-WizAuditLog.md
@@ -11,7 +11,7 @@ Gets audit logs from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizAuditLog [-PageSize <int>] [-StartDate <datetime>] [-EndDate <datetime>] [-User <string>] [-Action <string>] [-Status <string>] [-MaxResults <int>] [<CommonParameters>]
+Get-WizAuditLog [-PageSize <int>] [-StartDate <DateTime>] [-EndDate <DateTime>] [-User <string>] [-Action <string>] [-Status <string>] [-MaxResults <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -55,7 +55,7 @@ Accept wildcard characters: False
 Filter by end date.
 
 ```yaml
-Type: Nullable`1
+Type: DateTime
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 Maximum number of audit logs to retrieve. Default is unlimited.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -103,7 +103,7 @@ Accept wildcard characters: False
 Filter by start date.
 
 ```yaml
-Type: Nullable`1
+Type: DateTime
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizAuditLog.md
+++ b/Module/Docs/Get-WizAuditLog.md
@@ -1,0 +1,170 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizAuditLog
+## SYNOPSIS
+Gets audit logs from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizAuditLog [-PageSize <int>] [-StartDate <datetime>] [-EndDate <datetime>] [-User <string>] [-Action <string>] [-Status <string>] [-MaxResults <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves records of user actions and system events.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizAuditLog
+```
+
+Returns audit logs using default paging.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizAuditLog -User admin@example.com -StartDate (Get-Date).AddDays(-1)
+```
+
+Retrieves actions for the specified user in the last day.
+
+## PARAMETERS
+
+### -Action
+Filter by action.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EndDate
+Filter by end date.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxResults
+Maximum number of audit logs to retrieve. Default is unlimited.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+The number of audit logs to retrieve per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartDate
+Filter by start date.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Status
+Filter by status.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -User
+Filter by user.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue, ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String`
+
+## OUTPUTS
+
+- `WizCloud.WizAuditLogEntry`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Audit logs may be extensive; apply date or user filters to narrow the output.

--- a/Module/Docs/Get-WizCloudAccount.md
+++ b/Module/Docs/Get-WizCloudAccount.md
@@ -1,0 +1,90 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizCloudAccount
+## SYNOPSIS
+Gets cloud accounts from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizCloudAccount [-PageSize <int>] [-MaxResults <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Enumerates cloud provider accounts linked to your organization.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizCloudAccount
+```
+
+Lists every account accessible to the current connection.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizCloudAccount -MaxResults 50 -PageSize 50
+```
+
+Retrieves at most fifty accounts in pages of fifty.
+
+## PARAMETERS
+
+### -MaxResults
+Maximum number of cloud accounts to retrieve. Default is unlimited.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+The number of cloud accounts to retrieve per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `WizCloud.WizCloudAccount`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Retrieving many accounts may trigger API rate limiting.

--- a/Module/Docs/Get-WizCloudAccount.md
+++ b/Module/Docs/Get-WizCloudAccount.md
@@ -11,7 +11,7 @@ Gets cloud accounts from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizCloudAccount [-PageSize <int>] [-MaxResults <int>] [<CommonParameters>]
+Get-WizCloudAccount [-PageSize <int>] [-MaxResults <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Retrieves at most fifty accounts in pages of fifty.
 Maximum number of cloud accounts to retrieve. Default is unlimited.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizCompliance.md
+++ b/Module/Docs/Get-WizCompliance.md
@@ -11,7 +11,7 @@ Gets compliance posture from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizCompliance [-Framework <string[]>] [-MinScore <double>] [<CommonParameters>]
+Get-WizCompliance [-Framework <string[]>] [-MinScore <Double>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -55,7 +55,7 @@ Accept wildcard characters: False
 Filter by minimum compliance score.
 
 ```yaml
-Type: Nullable`1
+Type: Double
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizCompliance.md
+++ b/Module/Docs/Get-WizCompliance.md
@@ -1,0 +1,90 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizCompliance
+## SYNOPSIS
+Gets compliance posture from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizCompliance [-Framework <string[]>] [-MinScore <double>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves compliance scores for supported frameworks.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizCompliance
+```
+
+Returns compliance scores for all available frameworks.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizCompliance -Framework CIS -MinScore 80
+```
+
+Shows CIS results with scores of at least 80.
+
+## PARAMETERS
+
+### -Framework
+Filter by compliance framework.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinScore
+Filter by minimum compliance score.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `WizCloud.WizComplianceResult`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Results represent the latest assessment and may change as new scans run.

--- a/Module/Docs/Get-WizConfigurationFinding.md
+++ b/Module/Docs/Get-WizConfigurationFinding.md
@@ -11,7 +11,7 @@ Gets configuration findings from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizConfigurationFinding [-PageSize <int>] [-Framework <string[]>] [-Severity <WizSeverity[]>] [-Category <string[]>] [-ProjectId <string>] [-MaxResults <int>] [<CommonParameters>]
+Get-WizConfigurationFinding [-PageSize <int>] [-Framework <string[]>] [-Severity <WizSeverity[]>] [-Category <string[]>] [-ProjectId <string>] [-MaxResults <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 Maximum number of findings to retrieve. Default is unlimited.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizConfigurationFinding.md
+++ b/Module/Docs/Get-WizConfigurationFinding.md
@@ -1,0 +1,154 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizConfigurationFinding
+## SYNOPSIS
+Gets configuration findings from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizConfigurationFinding [-PageSize <int>] [-Framework <string[]>] [-Severity <WizSeverity[]>] [-Category <string[]>] [-ProjectId <string>] [-MaxResults <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves configuration assessment results from the Wiz platform.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizConfigurationFinding
+```
+
+Returns all available configuration findings.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizConfigurationFinding -Framework CIS
+```
+
+Retrieves findings related to the CIS framework.
+
+## PARAMETERS
+
+### -Category
+Filter by category.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Framework
+Filter by compliance framework.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxResults
+Maximum number of findings to retrieve. Default is unlimited.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+The number of findings to retrieve per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectId
+Filter by project identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Severity
+Filter by severity.
+
+```yaml
+Type: WizSeverity[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: INFORMATIONAL, LOW, MEDIUM, HIGH, CRITICAL
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String`
+
+## OUTPUTS
+
+- `WizCloud.WizConfigurationFinding`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Use filters such as framework or severity to limit the amount of data returned.

--- a/Module/Docs/Get-WizIssue.md
+++ b/Module/Docs/Get-WizIssue.md
@@ -1,0 +1,154 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizIssue
+## SYNOPSIS
+Gets security issues from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizIssue [-PageSize <int>] [-Severity <WizSeverity[]>] [-Status <string[]>] [-ProjectId <string>] [-Type <string[]>] [-MaxResults <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Streams security issues reported by the Wiz platform.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizIssue
+```
+
+Returns every issue available to the current connection.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizIssue -Severity High
+```
+
+Retrieves only high-severity issues.
+
+## PARAMETERS
+
+### -MaxResults
+Maximum number of issues to retrieve. Default is unlimited.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+The number of issues to retrieve per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectId
+Filter by project identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Severity
+Filter by issue severities.
+
+```yaml
+Type: WizSeverity[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: INFORMATIONAL, LOW, MEDIUM, HIGH, CRITICAL
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Status
+Filter by issue status.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Filter by issue types.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String`
+
+## OUTPUTS
+
+- `WizCloud.WizIssue`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Retrieving all issues may produce a large volume of output and take considerable time.

--- a/Module/Docs/Get-WizIssue.md
+++ b/Module/Docs/Get-WizIssue.md
@@ -11,7 +11,7 @@ Gets security issues from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizIssue [-PageSize <int>] [-Severity <WizSeverity[]>] [-Status <string[]>] [-ProjectId <string>] [-Type <string[]>] [-MaxResults <int>] [<CommonParameters>]
+Get-WizIssue [-PageSize <int>] [-Severity <WizSeverity[]>] [-Status <string[]>] [-ProjectId <string>] [-Type <string[]>] [-MaxResults <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Retrieves only high-severity issues.
 Maximum number of issues to retrieve. Default is unlimited.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizNetworkExposure.md
+++ b/Module/Docs/Get-WizNetworkExposure.md
@@ -11,7 +11,7 @@ Gets network exposure data from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizNetworkExposure [-PageSize <int>] [-Port <int[]>] [-Protocol <string[]>] [-InternetFacing <bool>] [-ProjectId <string>] [-MaxResults <int>] [<CommonParameters>]
+Get-WizNetworkExposure [-PageSize <int>] [-Port <int[]>] [-Protocol <string[]>] [-InternetFacing <Boolean>] [-ProjectId <string>] [-MaxResults <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Retrieves exposures for TCP port 443.
 Filter by internet facing status.
 
 ```yaml
-Type: Nullable`1
+Type: Boolean
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -55,7 +55,7 @@ Accept wildcard characters: False
 Maximum number of exposures to retrieve. Default is unlimited.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizNetworkExposure.md
+++ b/Module/Docs/Get-WizNetworkExposure.md
@@ -1,0 +1,154 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizNetworkExposure
+## SYNOPSIS
+Gets network exposure data from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizNetworkExposure [-PageSize <int>] [-Port <int[]>] [-Protocol <string[]>] [-InternetFacing <bool>] [-ProjectId <string>] [-MaxResults <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves open port and protocol exposure information.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizNetworkExposure
+```
+
+Returns every network exposure record.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizNetworkExposure -Port 443 -Protocol tcp
+```
+
+Retrieves exposures for TCP port 443.
+
+## PARAMETERS
+
+### -InternetFacing
+Filter by internet facing status.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxResults
+Maximum number of exposures to retrieve. Default is unlimited.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+The number of exposures to retrieve per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Port
+Filter by port.
+
+```yaml
+Type: Int32[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectId
+Filter by project identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Protocol
+Filter by protocol.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String`
+
+## OUTPUTS
+
+- `WizCloud.WizNetworkExposure`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Use port or protocol filters to limit the volume of returned data.

--- a/Module/Docs/Get-WizProject.md
+++ b/Module/Docs/Get-WizProject.md
@@ -1,0 +1,90 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizProject
+## SYNOPSIS
+Gets projects from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizProject [-PageSize <int>] [-MaxResults <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves project and folder information from the Wiz API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizProject
+```
+
+Returns every project for the connected organization.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizProject -PageSize 100
+```
+
+Retrieves projects in pages of one hundred.
+
+## PARAMETERS
+
+### -MaxResults
+Maximum number of projects to retrieve. Default is unlimited.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+The number of projects to retrieve per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `WizCloud.WizProject`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Projects are returned in pages and may include folder entries.

--- a/Module/Docs/Get-WizProject.md
+++ b/Module/Docs/Get-WizProject.md
@@ -11,7 +11,7 @@ Gets projects from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizProject [-PageSize <int>] [-MaxResults <int>] [<CommonParameters>]
+Get-WizProject [-PageSize <int>] [-MaxResults <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Retrieves projects in pages of one hundred.
 Maximum number of projects to retrieve. Default is unlimited.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizResource.md
+++ b/Module/Docs/Get-WizResource.md
@@ -11,7 +11,7 @@ Gets cloud resources from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizResource [-PageSize <int>] [-Type <string[]>] [-CloudProvider <WizCloudProvider[]>] [-Region <string>] [-PubliclyAccessible] [-Tag <hashtable>] [-ProjectId <string>] [-MaxResults <int>] [<CommonParameters>]
+Get-WizResource [-PageSize <int>] [-Type <string[]>] [-CloudProvider <WizCloudProvider[]>] [-Region <string>] [-PubliclyAccessible] [-Tag <hashtable>] [-ProjectId <string>] [-MaxResults <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -55,7 +55,7 @@ Accept wildcard characters: False
 Maximum number of resources to retrieve. Default is unlimited.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizResource.md
+++ b/Module/Docs/Get-WizResource.md
@@ -1,0 +1,186 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizResource
+## SYNOPSIS
+Gets cloud resources from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizResource [-PageSize <int>] [-Type <string[]>] [-CloudProvider <WizCloudProvider[]>] [-Region <string>] [-PubliclyAccessible] [-Tag <hashtable>] [-ProjectId <string>] [-MaxResults <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves resource inventory items from the Wiz API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizResource
+```
+
+Returns all resources visible to the current connection.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizResource -Type vm -PageSize 100
+```
+
+Retrieves virtual machines 100 at a time.
+
+## PARAMETERS
+
+### -CloudProvider
+Filter by cloud provider.
+
+```yaml
+Type: WizCloudProvider[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: AWS, AZURE, GCP, ALIBABA, OCI, KUBERNETES
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxResults
+Maximum number of resources to retrieve. Default is unlimited.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+The number of resources to retrieve per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectId
+Filter by project identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PubliclyAccessible
+Filter by public accessibility.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Region
+Filter by resource region.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Tag
+Filter by tags.
+
+```yaml
+Type: Hashtable
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Filter by resource type.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String`
+
+## OUTPUTS
+
+- `WizCloud.WizResource`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Large result sets may require multiple API requests and increase run time.

--- a/Module/Docs/Get-WizUser.md
+++ b/Module/Docs/Get-WizUser.md
@@ -11,7 +11,7 @@ Gets users from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizUser [-PageSize <int>] [-Type <WizUserType[]>] [-ProjectId <string>] [-MaxResults <int>] [-Raw] [<CommonParameters>]
+Get-WizUser [-PageSize <int>] [-Type <WizUserType[]>] [-ProjectId <string>] [-MaxResults <Int32>] [-Raw] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -39,7 +39,7 @@ Outputs the first ten users using the raw API response.
 Maximum number of users to retrieve. Default is unlimited.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizUser.md
+++ b/Module/Docs/Get-WizUser.md
@@ -1,0 +1,139 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizUser
+## SYNOPSIS
+Gets users from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizUser [-PageSize <int>] [-Type <WizUserType[]>] [-ProjectId <string>] [-MaxResults <int>] [-Raw] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves user identities along with security properties and related projects.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizUser
+```
+
+Retrieves enhanced user objects for the current connection.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizUser -MaxResults 10 -Raw
+```
+
+Outputs the first ten users using the raw API response.
+
+## PARAMETERS
+
+### -MaxResults
+Maximum number of users to retrieve. Default is unlimited.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+The number of users to retrieve per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectId
+Filter by project identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -Raw
+Return raw API response objects.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+Filter by Wiz user types.
+
+```yaml
+Type: WizUserType[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values: USER_ACCOUNT, SERVICE_ACCOUNT, GROUP, ACCESS_KEY
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String`
+
+## OUTPUTS
+
+- `WizCloud.WizUserComprehensive`
+- `WizCloud.WizUser`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Using -Raw returns original API objects and may consume additional memory.

--- a/Module/Docs/Get-WizVulnerability.md
+++ b/Module/Docs/Get-WizVulnerability.md
@@ -11,7 +11,7 @@ Gets vulnerabilities from Wiz.io.
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Get-WizVulnerability [-PageSize <int>] [-CVE <string>] [-MinCVSS <double>] [-ExploitAvailable] [-ProjectId <string>] [-MaxResults <int>] [<CommonParameters>]
+Get-WizVulnerability [-PageSize <int>] [-CVE <string>] [-MinCVSS <Double>] [-ExploitAvailable] [-ProjectId <string>] [-MaxResults <Int32>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -71,7 +71,7 @@ Accept wildcard characters: False
 Maximum number of vulnerabilities to retrieve. Default is unlimited.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -87,7 +87,7 @@ Accept wildcard characters: False
 Filter by minimum CVSS score.
 
 ```yaml
-Type: Nullable`1
+Type: Double
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Get-WizVulnerability.md
+++ b/Module/Docs/Get-WizVulnerability.md
@@ -1,0 +1,154 @@
+---
+external help file: WizCloud-help.xml
+Module Name: WizCloud
+online version: https://github.com/EvotecIT/WizCloud
+schema: 2.0.0
+---
+# Get-WizVulnerability
+## SYNOPSIS
+Gets vulnerabilities from Wiz.io.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-WizVulnerability [-PageSize <int>] [-CVE <string>] [-MinCVSS <double>] [-ExploitAvailable] [-ProjectId <string>] [-MaxResults <int>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves vulnerability information for resources.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+PS> Get-WizVulnerability
+```
+
+Returns every vulnerability visible to the connection.
+
+### EXAMPLE 2
+```powershell
+PS> Get-WizVulnerability -CVE CVE-2024-0001
+```
+
+Displays details for the specified CVE.
+
+## PARAMETERS
+
+### -CVE
+Filter by CVE identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExploitAvailable
+Filter to vulnerabilities with an available exploit.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MaxResults
+Maximum number of vulnerabilities to retrieve. Default is unlimited.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -MinCVSS
+Filter by minimum CVSS score.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PageSize
+The number of vulnerabilities to retrieve per page.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProjectId
+Filter by project identifier.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String`
+
+## OUTPUTS
+
+- `WizCloud.WizVulnerability`
+
+## RELATED LINKS
+
+- [PowerShell documentation](https://learn.microsoft.com/powershell/scripting/overview)
+- [Project documentation](https://github.com/EvotecIT/WizCloud)
+
+## NOTES
+
+### Note
+
+Use filters such as -CVE or -ExploitAvailable to reduce result volume.

--- a/Module/Docs/Readme.md
+++ b/Module/Docs/Readme.md
@@ -1,0 +1,47 @@
+---
+Module Name: WizCloud
+Module Guid: c6d394bc-7494-4619-b006-a073a6e76598
+Download Help Link: https://github.com/EvotecIT/WizCloud
+Help Version: 1.0.0
+Locale: en-US
+---
+# WizCloud Module
+## Description
+WizCloud is a PowerShell module that provides a set of cmdlets for managing and interacting with Wiz.io service
+
+## WizCloud Cmdlets
+### [Connect-Wiz](Connect-Wiz.md)
+Connects to Wiz.io and stores authentication for the session.
+
+### [Disconnect-Wiz](Disconnect-Wiz.md)
+Clears Wiz authentication from the current session.
+
+### [Get-WizAuditLog](Get-WizAuditLog.md)
+Gets audit logs from Wiz.io.
+
+### [Get-WizCloudAccount](Get-WizCloudAccount.md)
+Gets cloud accounts from Wiz.io.
+
+### [Get-WizCompliance](Get-WizCompliance.md)
+Gets compliance posture from Wiz.io.
+
+### [Get-WizConfigurationFinding](Get-WizConfigurationFinding.md)
+Gets configuration findings from Wiz.io.
+
+### [Get-WizIssue](Get-WizIssue.md)
+Gets security issues from Wiz.io.
+
+### [Get-WizNetworkExposure](Get-WizNetworkExposure.md)
+Gets network exposure data from Wiz.io.
+
+### [Get-WizProject](Get-WizProject.md)
+Gets projects from Wiz.io.
+
+### [Get-WizResource](Get-WizResource.md)
+Gets cloud resources from Wiz.io.
+
+### [Get-WizUser](Get-WizUser.md)
+Gets users from Wiz.io.
+
+### [Get-WizVulnerability](Get-WizVulnerability.md)
+Gets vulnerabilities from Wiz.io.

--- a/Module/WizCloud.psd1
+++ b/Module/WizCloud.psd1
@@ -1,4 +1,4 @@
-@{
+﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
     CmdletsToExport      = @('Connect-Wiz', 'Disconnect-Wiz', 'Get-WizAuditLog', 'Get-WizCloudAccount', 'Get-WizCompliance', 'Get-WizConfigurationFinding', 'Get-WizIssue', 'Get-WizNetworkExposure', 'Get-WizProject', 'Get-WizResource', 'Get-WizUser', 'Get-WizVulnerability')

--- a/Module/WizCloud.psd1
+++ b/Module/WizCloud.psd1
@@ -1,10 +1,10 @@
-﻿@{
+@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
     CmdletsToExport      = @('Connect-Wiz', 'Disconnect-Wiz', 'Get-WizAuditLog', 'Get-WizCloudAccount', 'Get-WizCompliance', 'Get-WizConfigurationFinding', 'Get-WizIssue', 'Get-WizNetworkExposure', 'Get-WizProject', 'Get-WizResource', 'Get-WizUser', 'Get-WizVulnerability')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
-    Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'
+    Copyright            = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'
     Description          = 'WizCloud is a PowerShell module that provides a set of cmdlets for managing and interacting with Wiz.io service'
     FunctionsToExport    = @()
     GUID                 = 'c6d394bc-7494-4619-b006-a073a6e76598'
@@ -12,9 +12,13 @@
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{
-            ProjectUri = 'https://github.com/EvotecIT/WizCloud'
-            Tags       = @('Windows', 'MacOS', 'Linux')
+            ProjectUri                 = 'https://github.com/EvotecIT/WizCloud'
+            Tags                       = @('Windows', 'MacOS', 'Linux')
+            RequireLicenseAcceptance   = $false
+            ExternalModuleDependencies = @()
         }
     }
     RootModule           = 'WizCloud.psm1'
+    RequiredModules      = @()
+    ScriptsToProcess     = @()
 }

--- a/Module/en-US/WizCloud-help.xml
+++ b/Module/en-US/WizCloud-help.xml
@@ -1,0 +1,2259 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Connect-Wiz</command:name>
+      <command:verb>Connect</command:verb>
+      <command:noun>Wiz</command:noun>
+      <maml:description>
+        <maml:para>Connects to Wiz.io and stores authentication for the session.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Establishes a connection using a token or client credentials and optionally tests the API.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="TokenParameterSet">
+        <maml:name>Connect-Wiz</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Region</maml:name>
+          <maml:description>
+            <maml:para>The Wiz region to connect to (e.g., 'eu17', 'us1', 'us2').</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">WizRegion</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">EU1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EU2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EU17</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">US1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">US2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">USGOV1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AP1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AP2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CA1</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>WizRegion</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Suppress</maml:name>
+          <maml:description>
+            <maml:para>Suppress the output messages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TestConnection</maml:name>
+          <maml:description>
+            <maml:para>Test the connection to Wiz.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>Token</maml:name>
+          <maml:description>
+            <maml:para>The Wiz service account token for authentication.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ClientCredentialParameterSet">
+        <maml:name>Connect-Wiz</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientId</maml:name>
+          <maml:description>
+            <maml:para>The Wiz service account client ID.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClientSecret</maml:name>
+          <maml:description>
+            <maml:para>The Wiz service account client secret.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Region</maml:name>
+          <maml:description>
+            <maml:para>The Wiz region to connect to (e.g., 'eu17', 'us1', 'us2').</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">WizRegion</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">EU1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EU2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EU17</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">US1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">US2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">USGOV1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AP1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AP2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CA1</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>WizRegion</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Suppress</maml:name>
+          <maml:description>
+            <maml:para>Suppress the output messages.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>TestConnection</maml:name>
+          <maml:description>
+            <maml:para>Test the connection to Wiz.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClientId</maml:name>
+        <maml:description>
+          <maml:para>The Wiz service account client ID.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClientSecret</maml:name>
+        <maml:description>
+          <maml:para>The Wiz service account client secret.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Region</maml:name>
+        <maml:description>
+          <maml:para>The Wiz region to connect to (e.g., 'eu17', 'us1', 'us2').</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">WizRegion</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">EU1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">EU2</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">EU17</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">US1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">US2</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">USGOV1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AP1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AP2</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CA1</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>WizRegion</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Suppress</maml:name>
+        <maml:description>
+          <maml:para>Suppress the output messages.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>TestConnection</maml:name>
+        <maml:description>
+          <maml:para>Test the connection to Wiz.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>Token</maml:name>
+        <maml:description>
+          <maml:para>The Wiz service account token for authentication.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Boolean</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Stored credentials remain in memory until Disconnect-Wiz is executed.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Connect using a token</maml:title>
+        <dev:code>PS&gt; Connect-Wiz -Token 'your-service-account-token'</dev:code>
+        <dev:remarks>
+          <maml:para>The token is cached for subsequent cmdlets.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Connect with client credentials</maml:title>
+        <dev:code>PS&gt; Connect-Wiz -ClientId 'id' -ClientSecret 'secret' -Region us1</dev:code>
+        <dev:remarks>
+          <maml:para>A token is acquired for region us1.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Disconnect-Wiz</command:name>
+      <command:verb>Disconnect</command:verb>
+      <command:noun>Wiz</command:noun>
+      <maml:description>
+        <maml:para>Clears Wiz authentication from the current session.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Removes stored tokens, credentials, and region information for the session.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Disconnect-Wiz</maml:name>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters />
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>System.Boolean</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Disconnecting deletes authentication details and cannot be undone for the current session.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Disconnect the current session</maml:title>
+        <dev:code>PS&gt; Disconnect-Wiz</dev:code>
+        <dev:remarks>
+          <maml:para>This example clears any stored Wiz authentication information.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Disconnect after connecting</maml:title>
+        <dev:code>PS&gt; Connect-Wiz -Token 'token'; Disconnect-Wiz</dev:code>
+        <dev:remarks>
+          <maml:para>The connection created with Connect-Wiz is removed.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizAuditLog</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizAuditLog</command:noun>
+      <maml:description>
+        <maml:para>Gets audit logs from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieves records of user actions and system events.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizAuditLog</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Action</maml:name>
+          <maml:description>
+            <maml:para>Filter by action.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EndDate</maml:name>
+          <maml:description>
+            <maml:para>Filter by end date.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxResults</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of audit logs to retrieve. Default is unlimited.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>The number of audit logs to retrieve per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>StartDate</maml:name>
+          <maml:description>
+            <maml:para>Filter by start date.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Status</maml:name>
+          <maml:description>
+            <maml:para>Filter by status.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue, ByPropertyName)" position="named" aliases="None">
+          <maml:name>User</maml:name>
+          <maml:description>
+            <maml:para>Filter by user.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Action</maml:name>
+        <maml:description>
+          <maml:para>Filter by action.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>EndDate</maml:name>
+        <maml:description>
+          <maml:para>Filter by end date.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxResults</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of audit logs to retrieve. Default is unlimited.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>The number of audit logs to retrieve per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>StartDate</maml:name>
+        <maml:description>
+          <maml:para>Filter by start date.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Status</maml:name>
+        <maml:description>
+          <maml:para>Filter by status.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByValue, ByPropertyName)" position="named" aliases="None">
+        <maml:name>User</maml:name>
+        <maml:description>
+          <maml:para>Filter by user.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizAuditLogEntry</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Audit logs may be extensive; apply date or user filters to narrow the output.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get recent audit logs</maml:title>
+        <dev:code>PS&gt; Get-WizAuditLog</dev:code>
+        <dev:remarks>
+          <maml:para>Returns audit logs using default paging.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Filter by user and date</maml:title>
+        <dev:code>PS&gt; Get-WizAuditLog -User admin@example.com -StartDate (Get-Date).AddDays(-1)</dev:code>
+        <dev:remarks>
+          <maml:para>Retrieves actions for the specified user in the last day.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizCloudAccount</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizCloudAccount</command:noun>
+      <maml:description>
+        <maml:para>Gets cloud accounts from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Enumerates cloud provider accounts linked to your organization.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizCloudAccount</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxResults</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of cloud accounts to retrieve. Default is unlimited.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>The number of cloud accounts to retrieve per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxResults</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of cloud accounts to retrieve. Default is unlimited.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>The number of cloud accounts to retrieve per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizCloudAccount</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Retrieving many accounts may trigger API rate limiting.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get all cloud accounts</maml:title>
+        <dev:code>PS&gt; Get-WizCloudAccount</dev:code>
+        <dev:remarks>
+          <maml:para>Lists every account accessible to the current connection.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Limit the number of accounts</maml:title>
+        <dev:code>PS&gt; Get-WizCloudAccount -MaxResults 50 -PageSize 50</dev:code>
+        <dev:remarks>
+          <maml:para>Retrieves at most fifty accounts in pages of fifty.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizCompliance</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizCompliance</command:noun>
+      <maml:description>
+        <maml:para>Gets compliance posture from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieves compliance scores for supported frameworks.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizCompliance</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Framework</maml:name>
+          <maml:description>
+            <maml:para>Filter by compliance framework.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinScore</maml:name>
+          <maml:description>
+            <maml:para>Filter by minimum compliance score.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Framework</maml:name>
+        <maml:description>
+          <maml:para>Filter by compliance framework.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MinScore</maml:name>
+        <maml:description>
+          <maml:para>Filter by minimum compliance score.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizComplianceResult</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Results represent the latest assessment and may change as new scans run.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get compliance posture</maml:title>
+        <dev:code>PS&gt; Get-WizCompliance</dev:code>
+        <dev:remarks>
+          <maml:para>Returns compliance scores for all available frameworks.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Filter by framework and score</maml:title>
+        <dev:code>PS&gt; Get-WizCompliance -Framework CIS -MinScore 80</dev:code>
+        <dev:remarks>
+          <maml:para>Shows CIS results with scores of at least 80.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizConfigurationFinding</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizConfigurationFinding</command:noun>
+      <maml:description>
+        <maml:para>Gets configuration findings from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieves configuration assessment results from the Wiz platform.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizConfigurationFinding</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Category</maml:name>
+          <maml:description>
+            <maml:para>Filter by category.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Framework</maml:name>
+          <maml:description>
+            <maml:para>Filter by compliance framework.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxResults</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of findings to retrieve. Default is unlimited.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>The number of findings to retrieve per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+          <maml:name>ProjectId</maml:name>
+          <maml:description>
+            <maml:para>Filter by project identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Severity</maml:name>
+          <maml:description>
+            <maml:para>Filter by severity.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">WizSeverity[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">INFORMATIONAL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOW</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MEDIUM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIGH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CRITICAL</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>WizSeverity[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Category</maml:name>
+        <maml:description>
+          <maml:para>Filter by category.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Framework</maml:name>
+        <maml:description>
+          <maml:para>Filter by compliance framework.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxResults</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of findings to retrieve. Default is unlimited.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>The number of findings to retrieve per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+        <maml:name>ProjectId</maml:name>
+        <maml:description>
+          <maml:para>Filter by project identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Severity</maml:name>
+        <maml:description>
+          <maml:para>Filter by severity.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">WizSeverity[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">INFORMATIONAL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LOW</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MEDIUM</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HIGH</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CRITICAL</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>WizSeverity[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizConfigurationFinding</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Use filters such as framework or severity to limit the amount of data returned.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get configuration findings</maml:title>
+        <dev:code>PS&gt; Get-WizConfigurationFinding</dev:code>
+        <dev:remarks>
+          <maml:para>Returns all available configuration findings.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Filter by framework</maml:title>
+        <dev:code>PS&gt; Get-WizConfigurationFinding -Framework CIS</dev:code>
+        <dev:remarks>
+          <maml:para>Retrieves findings related to the CIS framework.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizIssue</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizIssue</command:noun>
+      <maml:description>
+        <maml:para>Gets security issues from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Streams security issues reported by the Wiz platform.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizIssue</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxResults</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of issues to retrieve. Default is unlimited.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>The number of issues to retrieve per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+          <maml:name>ProjectId</maml:name>
+          <maml:description>
+            <maml:para>Filter by project identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Severity</maml:name>
+          <maml:description>
+            <maml:para>Filter by issue severities.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">WizSeverity[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">INFORMATIONAL</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">LOW</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MEDIUM</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">HIGH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CRITICAL</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>WizSeverity[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Status</maml:name>
+          <maml:description>
+            <maml:para>Filter by issue status.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Filter by issue types.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxResults</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of issues to retrieve. Default is unlimited.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>The number of issues to retrieve per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+        <maml:name>ProjectId</maml:name>
+        <maml:description>
+          <maml:para>Filter by project identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Severity</maml:name>
+        <maml:description>
+          <maml:para>Filter by issue severities.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">WizSeverity[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">INFORMATIONAL</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">LOW</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MEDIUM</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HIGH</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CRITICAL</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>WizSeverity[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Status</maml:name>
+        <maml:description>
+          <maml:para>Filter by issue status.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>Filter by issue types.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizIssue</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Retrieving all issues may produce a large volume of output and take considerable time.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get all issues</maml:title>
+        <dev:code>PS&gt; Get-WizIssue</dev:code>
+        <dev:remarks>
+          <maml:para>Returns every issue available to the current connection.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Filter by severity</maml:title>
+        <dev:code>PS&gt; Get-WizIssue -Severity High</dev:code>
+        <dev:remarks>
+          <maml:para>Retrieves only high-severity issues.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizNetworkExposure</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizNetworkExposure</command:noun>
+      <maml:description>
+        <maml:para>Gets network exposure data from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieves open port and protocol exposure information.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizNetworkExposure</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>InternetFacing</maml:name>
+          <maml:description>
+            <maml:para>Filter by internet facing status.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxResults</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of exposures to retrieve. Default is unlimited.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>The number of exposures to retrieve per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Port</maml:name>
+          <maml:description>
+            <maml:para>Filter by port.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32[]</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+          <maml:name>ProjectId</maml:name>
+          <maml:description>
+            <maml:para>Filter by project identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Protocol</maml:name>
+          <maml:description>
+            <maml:para>Filter by protocol.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>InternetFacing</maml:name>
+        <maml:description>
+          <maml:para>Filter by internet facing status.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxResults</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of exposures to retrieve. Default is unlimited.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>The number of exposures to retrieve per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Port</maml:name>
+        <maml:description>
+          <maml:para>Filter by port.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32[]</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+        <maml:name>ProjectId</maml:name>
+        <maml:description>
+          <maml:para>Filter by project identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Protocol</maml:name>
+        <maml:description>
+          <maml:para>Filter by protocol.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizNetworkExposure</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Use port or protocol filters to limit the volume of returned data.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get all network exposures</maml:title>
+        <dev:code>PS&gt; Get-WizNetworkExposure</dev:code>
+        <dev:remarks>
+          <maml:para>Returns every network exposure record.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Filter by port and protocol</maml:title>
+        <dev:code>PS&gt; Get-WizNetworkExposure -Port 443 -Protocol tcp</dev:code>
+        <dev:remarks>
+          <maml:para>Retrieves exposures for TCP port 443.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizProject</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizProject</command:noun>
+      <maml:description>
+        <maml:para>Gets projects from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieves project and folder information from the Wiz API.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizProject</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxResults</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of projects to retrieve. Default is unlimited.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>The number of projects to retrieve per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxResults</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of projects to retrieve. Default is unlimited.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>The number of projects to retrieve per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizProject</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Projects are returned in pages and may include folder entries.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get all projects</maml:title>
+        <dev:code>PS&gt; Get-WizProject</dev:code>
+        <dev:remarks>
+          <maml:para>Returns every project for the connected organization.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Specify page size</maml:title>
+        <dev:code>PS&gt; Get-WizProject -PageSize 100</dev:code>
+        <dev:remarks>
+          <maml:para>Retrieves projects in pages of one hundred.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizResource</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizResource</command:noun>
+      <maml:description>
+        <maml:para>Gets cloud resources from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieves resource inventory items from the Wiz API.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizResource</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CloudProvider</maml:name>
+          <maml:description>
+            <maml:para>Filter by cloud provider.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">WizCloudProvider[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">AWS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AZURE</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GCP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ALIBABA</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OCI</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">KUBERNETES</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>WizCloudProvider[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxResults</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of resources to retrieve. Default is unlimited.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>The number of resources to retrieve per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+          <maml:name>ProjectId</maml:name>
+          <maml:description>
+            <maml:para>Filter by project identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PubliclyAccessible</maml:name>
+          <maml:description>
+            <maml:para>Filter by public accessibility.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Region</maml:name>
+          <maml:description>
+            <maml:para>Filter by resource region.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Tag</maml:name>
+          <maml:description>
+            <maml:para>Filter by tags.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Filter by resource type.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CloudProvider</maml:name>
+        <maml:description>
+          <maml:para>Filter by cloud provider.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">WizCloudProvider[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">AWS</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">AZURE</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GCP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ALIBABA</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">OCI</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">KUBERNETES</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>WizCloudProvider[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxResults</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of resources to retrieve. Default is unlimited.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>The number of resources to retrieve per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+        <maml:name>ProjectId</maml:name>
+        <maml:description>
+          <maml:para>Filter by project identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PubliclyAccessible</maml:name>
+        <maml:description>
+          <maml:para>Filter by public accessibility.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Region</maml:name>
+        <maml:description>
+          <maml:para>Filter by resource region.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Tag</maml:name>
+        <maml:description>
+          <maml:para>Filter by tags.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>Filter by resource type.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizResource</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Large result sets may require multiple API requests and increase run time.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get all resources</maml:title>
+        <dev:code>PS&gt; Get-WizResource</dev:code>
+        <dev:remarks>
+          <maml:para>Returns all resources visible to the current connection.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Filter by type and page size</maml:title>
+        <dev:code>PS&gt; Get-WizResource -Type vm -PageSize 100</dev:code>
+        <dev:remarks>
+          <maml:para>Retrieves virtual machines 100 at a time.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizUser</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizUser</command:noun>
+      <maml:description>
+        <maml:para>Gets users from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieves user identities along with security properties and related projects.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizUser</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxResults</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of users to retrieve. Default is unlimited.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>The number of users to retrieve per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+          <maml:name>ProjectId</maml:name>
+          <maml:description>
+            <maml:para>Filter by project identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Raw</maml:name>
+          <maml:description>
+            <maml:para>Return raw API response objects.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Type</maml:name>
+          <maml:description>
+            <maml:para>Filter by Wiz user types.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">WizUserType[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">USER_ACCOUNT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SERVICE_ACCOUNT</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GROUP</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ACCESS_KEY</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>WizUserType[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxResults</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of users to retrieve. Default is unlimited.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>The number of users to retrieve per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+        <maml:name>ProjectId</maml:name>
+        <maml:description>
+          <maml:para>Filter by project identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Raw</maml:name>
+        <maml:description>
+          <maml:para>Return raw API response objects.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Type</maml:name>
+        <maml:description>
+          <maml:para>Filter by Wiz user types.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">WizUserType[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">USER_ACCOUNT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SERVICE_ACCOUNT</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">GROUP</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ACCESS_KEY</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>WizUserType[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizUserComprehensive</maml:name>
+        </dev:type>
+      </command:returnValue>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizUser</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Using -Raw returns original API objects and may consume additional memory.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get all users</maml:title>
+        <dev:code>PS&gt; Get-WizUser</dev:code>
+        <dev:remarks>
+          <maml:para>Retrieves enhanced user objects for the current connection.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Limit results and return raw objects</maml:title>
+        <dev:code>PS&gt; Get-WizUser -MaxResults 10 -Raw</dev:code>
+        <dev:remarks>
+          <maml:para>Outputs the first ten users using the raw API response.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-WizVulnerability</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>WizVulnerability</command:noun>
+      <maml:description>
+        <maml:para>Gets vulnerabilities from Wiz.io.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Retrieves vulnerability information for resources.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-WizVulnerability</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CVE</maml:name>
+          <maml:description>
+            <maml:para>Filter by CVE identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExploitAvailable</maml:name>
+          <maml:description>
+            <maml:para>Filter to vulnerabilities with an available exploit.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxResults</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of vulnerabilities to retrieve. Default is unlimited.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MinCVSS</maml:name>
+          <maml:description>
+            <maml:para>Filter by minimum CVSS score.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PageSize</maml:name>
+          <maml:description>
+            <maml:para>The number of vulnerabilities to retrieve per page.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+          <maml:name>ProjectId</maml:name>
+          <maml:description>
+            <maml:para>Filter by project identifier.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CVE</maml:name>
+        <maml:description>
+          <maml:para>Filter by CVE identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ExploitAvailable</maml:name>
+        <maml:description>
+          <maml:para>Filter to vulnerabilities with an available exploit.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MaxResults</maml:name>
+        <maml:description>
+          <maml:para>Maximum number of vulnerabilities to retrieve. Default is unlimited.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>MinCVSS</maml:name>
+        <maml:description>
+          <maml:para>Filter by minimum CVSS score.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PageSize</maml:name>
+        <maml:description>
+          <maml:para>The number of vulnerabilities to retrieve per page.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="True (ByPropertyName)" position="named" aliases="None">
+        <maml:name>ProjectId</maml:name>
+        <maml:description>
+          <maml:para>Filter by project identifier.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>WizCloud.WizVulnerability</maml:name>
+        </dev:type>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para>Use filters such as -CVE or -ExploitAvailable to reduce result volume.</maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>Get all vulnerabilities</maml:title>
+        <dev:code>PS&gt; Get-WizVulnerability</dev:code>
+        <dev:remarks>
+          <maml:para>Returns every vulnerability visible to the connection.</maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Retrieve a specific CVE</maml:title>
+        <dev:code>PS&gt; Get-WizVulnerability -CVE CVE-2024-0001</dev:code>
+        <dev:remarks>
+          <maml:para>Displays details for the specified CVE.</maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>PowerShell documentation</maml:linkText>
+        <maml:uri>https://learn.microsoft.com/powershell/scripting/overview</maml:uri>
+      </maml:navigationLink>
+      <maml:navigationLink>
+        <maml:linkText>Project documentation</maml:linkText>
+        <maml:uri>https://github.com/EvotecIT/WizCloud</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+</helpItems>

--- a/Module/en-US/WizCloud-help.xml
+++ b/Module/en-US/WizCloud-help.xml
@@ -377,9 +377,9 @@
           <maml:description>
             <maml:para>Filter by end date.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DateTime</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>DateTime</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -389,9 +389,9 @@
           <maml:description>
             <maml:para>Maximum number of audit logs to retrieve. Default is unlimited.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -413,9 +413,9 @@
           <maml:description>
             <maml:para>Filter by start date.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DateTime</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>DateTime</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -464,9 +464,9 @@
         <maml:description>
           <maml:para>Filter by end date.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">DateTime</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>DateTime</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -476,9 +476,9 @@
         <maml:description>
           <maml:para>Maximum number of audit logs to retrieve. Default is unlimited.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -500,9 +500,9 @@
         <maml:description>
           <maml:para>Filter by start date.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">DateTime</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>DateTime</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -598,9 +598,9 @@
           <maml:description>
             <maml:para>Maximum number of cloud accounts to retrieve. Default is unlimited.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -625,9 +625,9 @@
         <maml:description>
           <maml:para>Maximum number of cloud accounts to retrieve. Default is unlimited.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -723,9 +723,9 @@
           <maml:description>
             <maml:para>Filter by minimum compliance score.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Double</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -750,9 +750,9 @@
         <maml:description>
           <maml:para>Filter by minimum compliance score.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Double</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -848,9 +848,9 @@
           <maml:description>
             <maml:para>Maximum number of findings to retrieve. Default is unlimited.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -930,9 +930,9 @@
         <maml:description>
           <maml:para>Maximum number of findings to retrieve. Default is unlimited.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1047,9 +1047,9 @@
           <maml:description>
             <maml:para>Maximum number of issues to retrieve. Default is unlimited.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1129,9 +1129,9 @@
         <maml:description>
           <maml:para>Maximum number of issues to retrieve. Default is unlimited.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1270,9 +1270,9 @@
           <maml:description>
             <maml:para>Filter by internet facing status.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Boolean</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1282,9 +1282,9 @@
           <maml:description>
             <maml:para>Maximum number of exposures to retrieve. Default is unlimited.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1345,9 +1345,9 @@
         <maml:description>
           <maml:para>Filter by internet facing status.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Boolean</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1357,9 +1357,9 @@
         <maml:description>
           <maml:para>Maximum number of exposures to retrieve. Default is unlimited.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1479,9 +1479,9 @@
           <maml:description>
             <maml:para>Maximum number of projects to retrieve. Default is unlimited.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1506,9 +1506,9 @@
         <maml:description>
           <maml:para>Maximum number of projects to retrieve. Default is unlimited.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1612,9 +1612,9 @@
           <maml:description>
             <maml:para>Maximum number of resources to retrieve. Default is unlimited.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1719,9 +1719,9 @@
         <maml:description>
           <maml:para>Maximum number of resources to retrieve. Default is unlimited.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1865,9 +1865,9 @@
           <maml:description>
             <maml:para>Maximum number of users to retrieve. Default is unlimited.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1934,9 +1934,9 @@
         <maml:description>
           <maml:para>Maximum number of users to retrieve. Default is unlimited.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -2091,9 +2091,9 @@
           <maml:description>
             <maml:para>Maximum number of vulnerabilities to retrieve. Default is unlimited.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2103,9 +2103,9 @@
           <maml:description>
             <maml:para>Filter by minimum CVSS score.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Double</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2166,9 +2166,9 @@
         <maml:description>
           <maml:para>Maximum number of vulnerabilities to retrieve. Default is unlimited.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -2178,9 +2178,9 @@
         <maml:description>
           <maml:para>Filter by minimum CVSS score.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Double</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Double</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/WizCloud.PowerShell/WizCloud.PowerShell.csproj
+++ b/WizCloud.PowerShell/WizCloud.PowerShell.csproj
@@ -35,12 +35,8 @@
 
 
     <PropertyGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
+        <!-- PowerForge consumes compiler XML documentation when generating cmdlet help. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <XmlDoc2CmdletDocArguments>-strict</XmlDoc2CmdletDocArguments>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -51,20 +47,6 @@
     <Target Name="RemoveFilesAfterBuild" AfterTargets="Build">
         <Delete Files="$(OutDir)System.Management.Automation.dll" />
         <Delete Files="$(OutDir)System.Management.dll" />
-    </Target>
-
-    <ItemGroup>
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.6.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <!-- Copy help documentation to publish output after publish -->
-    <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">
-        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll-Help.xml"
-            DestinationFiles="$(PublishDir)$(AssemblyName).dll-Help.xml"
-            Condition="Exists('$(OutputPath)$(AssemblyName).dll-Help.xml')" />
     </Target>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary

- Removes the MatejKafka.XmlDoc2CmdletDoc dependency and its build targets.
- Uses the public PSPublishModule 3.0.88 / PowerForge documentation owner.
- Regenerates Markdown and MAML and keeps binary external help discoverable with the assembly-named alias.

## Validation

- Full public-package module build completed.
- Markdown and MAML command identities match; MAML parses as XML.
- Regeneration is idempotent.
- Generated help was exercised through PowerShell 7 and Windows PowerShell 5.1.
- Repository-native .NET builds pass for the supported target frameworks.

## Scope

This PR is intentionally limited to dependency removal and functional build/package/import/Get-Help preservation. Documentation-content debt such as prose, examples, defaults, output annotations, and display enrichment is recorded separately and is not hand-edited in generated artifacts here.